### PR TITLE
Add support for inverse operations

### DIFF
--- a/pennylane_cirq/cirq_device.py
+++ b/pennylane_cirq/cirq_device.py
@@ -156,10 +156,10 @@ class CirqDevice(Device):
         operation_name = operation
         inverse = False
 
-        if (operation.endswith(qml.Operation.string_for_inverse)):
-            operation_name = operation[:-len(qml.Operation.string_for_inverse)]
+        if operation.endswith(qml.Operation.string_for_inverse):
+            operation_name = operation[: -len(qml.Operation.string_for_inverse)]
             inverse = True
-            
+
         operation = self._operation_map[operation_name]
 
         if inverse:

--- a/pennylane_cirq/cirq_device.py
+++ b/pennylane_cirq/cirq_device.py
@@ -153,7 +153,17 @@ class CirqDevice(Device):
         self.reset()
 
     def apply(self, operation, wires, par):
-        operation = self._operation_map[operation]
+        operation_name = operation
+        inverse = False
+
+        if (operation.endswith(qml.Operation.string_for_inverse)):
+            operation_name = operation[:-len(qml.Operation.string_for_inverse)]
+            inverse = True
+            
+        operation = self._operation_map[operation_name]
+
+        if inverse:
+            operation = operation.inv()
 
         # If command is None do nothing
         if operation:

--- a/pennylane_cirq/cirq_device.py
+++ b/pennylane_cirq/cirq_device.py
@@ -163,7 +163,7 @@ class CirqDevice(Device):
         operation = self._operation_map[operation_name]
 
         if inverse:
-            operation = operation.inv()
+            operation.inv()
 
         # If command is None do nothing
         if operation:

--- a/pennylane_cirq/cirq_device.py
+++ b/pennylane_cirq/cirq_device.py
@@ -57,6 +57,7 @@ class CirqDevice(Device):
     pennylane_requires = ">=0.6.0"
     version = __version__
     author = "Johannes Jakob Meyer"
+    _capabilities = {"model": "qubit", "tensor_observables": False, "inverse_operations": True}
 
     short_name = "cirq.base_device"
 

--- a/pennylane_cirq/cirq_interface.py
+++ b/pennylane_cirq/cirq_interface.py
@@ -60,6 +60,7 @@ class CirqOperation:
 
         self.parametrization = parametrization
         self.parametrized_cirq_gates = None
+        self.is_inverse = False
 
     def parametrize(self, *args):
         """Parametrizes the CirqOperation.
@@ -72,6 +73,10 @@ class CirqOperation:
         if not isinstance(self.parametrized_cirq_gates, Sequence):
             self.parametrized_cirq_gates = [self.parametrized_cirq_gates]
 
+        if self.is_inverse:
+            # Cirq automatically reverses the order if it gets an iterable
+            self.parametrized_cirq_gates = cirq.inverse(self.parametrized_cirq_gates)
+
     def apply(self, *qubits):
         """Applies the CirqOperation.
 
@@ -82,6 +87,10 @@ class CirqOperation:
             raise qml.DeviceError("CirqOperation must be parametrized before it can be applied.")
 
         return (parametrized_gate(*qubits) for parametrized_gate in self.parametrized_cirq_gates)
+
+    def inv():
+        """Inverses the CirqOperation."""        
+        self.is_inverse = not self.is_inverse
 
 
 def unitary_matrix_gate(U):

--- a/pennylane_cirq/cirq_interface.py
+++ b/pennylane_cirq/cirq_interface.py
@@ -89,7 +89,10 @@ class CirqOperation:
         return (parametrized_gate(*qubits) for parametrized_gate in self.parametrized_cirq_gates)
 
     def inv(self):
-        """Inverses the CirqOperation."""        
+        """Inverses the CirqOperation."""
+        if self.parametrized_cirq_gates:
+            raise qml.DeviceError("CirqOperation must be inverted before it is parametrized.")
+
         self.is_inverse = not self.is_inverse
 
 

--- a/pennylane_cirq/cirq_interface.py
+++ b/pennylane_cirq/cirq_interface.py
@@ -92,7 +92,7 @@ class CirqOperation:
         """Inverses the CirqOperation."""
         # We can also support inversion after parametrization, but this is not necessary for the
         # PennyLane-Cirq codebase at the moment.
-        
+
         if self.parametrized_cirq_gates:
             raise qml.DeviceError("CirqOperation can't be inverted after it was parametrized.")
 

--- a/pennylane_cirq/cirq_interface.py
+++ b/pennylane_cirq/cirq_interface.py
@@ -92,8 +92,9 @@ class CirqOperation:
         """Inverses the CirqOperation."""
         # We can also support inversion after parametrization, but this is not necessary for the
         # PennyLane-Cirq codebase at the moment.
+        
         if self.parametrized_cirq_gates:
-            raise qml.DeviceError("CirqOperation must be inverted before it is parametrized.")
+            raise qml.DeviceError("CirqOperation can't be inverted after it was parametrized.")
 
         self.is_inverse = not self.is_inverse
 

--- a/pennylane_cirq/cirq_interface.py
+++ b/pennylane_cirq/cirq_interface.py
@@ -88,7 +88,7 @@ class CirqOperation:
 
         return (parametrized_gate(*qubits) for parametrized_gate in self.parametrized_cirq_gates)
 
-    def inv():
+    def inv(self):
         """Inverses the CirqOperation."""        
         self.is_inverse = not self.is_inverse
 

--- a/pennylane_cirq/cirq_interface.py
+++ b/pennylane_cirq/cirq_interface.py
@@ -90,6 +90,8 @@ class CirqOperation:
 
     def inv(self):
         """Inverses the CirqOperation."""
+        # We can also support inversion after parametrization, but this is not necessary for the
+        # PennyLane-Cirq codebase at the moment.
         if self.parametrized_cirq_gates:
             raise qml.DeviceError("CirqOperation must be inverted before it is parametrized.")
 

--- a/pennylane_cirq/simulator_device.py
+++ b/pennylane_cirq/simulator_device.py
@@ -69,7 +69,6 @@ class SimulatorDevice(CirqDevice):
     """
     name = "Cirq Simulator device for PennyLane"
     short_name = "cirq.simulator"
-    _capabilities = {"model": "qubit", "tensor_observables": False}
 
     def __init__(self, wires, shots=1000, analytic=True, qubits=None):
         super().__init__(wires, shots, qubits)

--- a/pennylane_cirq/simulator_device.py
+++ b/pennylane_cirq/simulator_device.py
@@ -187,7 +187,9 @@ class SimulatorDevice(CirqDevice):
 
     def probability(self):
         if self.state is None:
-            raise qml.DeviceError("Probability can not be computed because the internal state is None.")
+            raise qml.DeviceError(
+                "Probability can not be computed because the internal state is None."
+            )
 
         states = itertools.product(range(2), repeat=self.num_wires)
         probs = np.abs(self.state) ** 2

--- a/tests/test_cirq_device.py
+++ b/tests/test_cirq_device.py
@@ -381,17 +381,29 @@ class TestOperations:
     # fmt: off
     @pytest.mark.parametrize("gate,par,expected_cirq_gates", [
         ("CNOT", [], [cirq.CNOT]),
+        ("CNOT.inv", [], [cirq.CNOT ** -1]),
         ("SWAP", [], [cirq.SWAP]),
+        ("SWAP.inv", [], [cirq.SWAP ** -1]),
         ("CZ", [], [cirq.CZ]),
+        ("CZ.inv", [], [cirq.CZ ** -1]),
         ("CRX", [1.4], [cirq.ControlledGate(cirq.Rx(1.4))]),
         ("CRX", [-1.2], [cirq.ControlledGate(cirq.Rx(-1.2))]),
         ("CRX", [2], [cirq.ControlledGate(cirq.Rx(2))]),
+        ("CRX.inv", [1.4], [cirq.ControlledGate(cirq.Rx(-1.4))]),
+        ("CRX.inv", [-1.2], [cirq.ControlledGate(cirq.Rx(1.2))]),
+        ("CRX.inv", [2], [cirq.ControlledGate(cirq.Rx(-2))]),
         ("CRY", [1.4], [cirq.ControlledGate(cirq.Ry(1.4))]),
         ("CRY", [0], [cirq.ControlledGate(cirq.Ry(0))]),
         ("CRY", [-1.3], [cirq.ControlledGate(cirq.Ry(-1.3))]),
+        ("CRY.inv", [1.4], [cirq.ControlledGate(cirq.Ry(-1.4))]),
+        ("CRY.inv", [0], [cirq.ControlledGate(cirq.Ry(0))]),
+        ("CRY.inv", [-1.3], [cirq.ControlledGate(cirq.Ry(1.3))]),
         ("CRZ", [1.4], [cirq.ControlledGate(cirq.Rz(1.4))]),
         ("CRZ", [-1.1], [cirq.ControlledGate(cirq.Rz(-1.1))]),
         ("CRZ", [1], [cirq.ControlledGate(cirq.Rz(1))]),
+        ("CRZ.inv", [1.4], [cirq.ControlledGate(cirq.Rz(-1.4))]),
+        ("CRZ.inv", [-1.1], [cirq.ControlledGate(cirq.Rz(1.1))]),
+        ("CRZ.inv", [1], [cirq.ControlledGate(cirq.Rz(-1))]),
         ("CRot", [1.4, 2.3, -1.2],
             [
                 cirq.ControlledGate(cirq.Rz(1.4)),
@@ -413,6 +425,27 @@ class TestOperations:
                 cirq.ControlledGate(cirq.Rz(-1)),
             ],
         ),
+        ("CRot.inv", [1.4, 2.3, -1.2],
+            [
+                cirq.ControlledGate(cirq.Rz(1.2)),
+                cirq.ControlledGate(cirq.Ry(-2.3)),
+                cirq.ControlledGate(cirq.Rz(-1.4)),
+            ],
+        ),
+        ("CRot.inv", [1, 2, -1],
+            [
+                cirq.ControlledGate(cirq.Rz(1)),
+                cirq.ControlledGate(cirq.Ry(-2)),
+                cirq.ControlledGate(cirq.Rz(-1)),
+            ],
+        ),
+        ("CRot.inv", [-1.1, 0.2, -1],
+            [
+                cirq.ControlledGate(cirq.Rz(1)),
+                cirq.ControlledGate(cirq.Ry(-0.2)),
+                cirq.ControlledGate(cirq.Rz(1.1)),
+            ],
+        ),
         ("QubitUnitary", [np.eye(4)], [cirq.TwoQubitMatrixGate(np.eye(4))]),
         (
             "QubitUnitary",
@@ -430,6 +463,25 @@ class TestOperations:
                 cirq.TwoQubitMatrixGate(
                     np.array([[1, -1, -1, 1], [-1, -1, 1, 1], [-1, 1, -1, 1], [1, 1, 1, 1]]) / 2
                 )
+            ],
+        ),
+        ("QubitUnitary.inv", [np.eye(4)], [cirq.TwoQubitMatrixGate(np.eye(4)) ** -1]),
+        (
+            "QubitUnitary.inv",
+            [np.array([[0, 0, 0, 1], [0, 0, 1, 0], [0, 1, 0, 0], [1, 0, 0, 0]])],
+            [
+                cirq.TwoQubitMatrixGate(
+                    np.array([[0, 0, 0, 1], [0, 0, 1, 0], [0, 1, 0, 0], [1, 0, 0, 0]])
+                ) ** -1
+            ],
+        ),
+        (
+            "QubitUnitary.inv",
+            [np.array([[1, -1, -1, 1], [-1, -1, 1, 1], [-1, 1, -1, 1], [1, 1, 1, 1]]) / 2],
+            [
+                cirq.TwoQubitMatrixGate(
+                    np.array([[1, -1, -1, 1], [-1, -1, 1, 1], [-1, 1, -1, 1], [1, 1, 1, 1]]) / 2
+                ) ** -1
             ],
         ),
     ])

--- a/tests/test_cirq_device.py
+++ b/tests/test_cirq_device.py
@@ -346,6 +346,21 @@ class TestOperations:
                 [np.array([[-1, 1], [1, 1]]) / math.sqrt(2)],
                 [cirq.SingleQubitMatrixGate(np.array([[-1, 1], [1, 1]]) / math.sqrt(2))],
             ),
+            (
+                "QubitUnitary.inv",
+                [np.array([[1, 0], [0, 1]])],
+                [cirq.SingleQubitMatrixGate(np.array([[1, 0], [0, 1]])) ** -1],
+            ),
+            (
+                "QubitUnitary.inv",
+                [np.array([[1, 0], [0, -1]])],
+                [cirq.SingleQubitMatrixGate(np.array([[1, 0], [0, -1]])) ** -1],
+            ),
+            (
+                "QubitUnitary.inv",
+                [np.array([[-1, 1], [1, 1]]) / math.sqrt(2)],
+                [cirq.SingleQubitMatrixGate(np.array([[-1, 1], [1, 1]]) / math.sqrt(2)) ** -1],
+            ),
         ],
     )
     # fmt: on

--- a/tests/test_cirq_device.py
+++ b/tests/test_cirq_device.py
@@ -219,8 +219,6 @@ class TestOperations:
 
         assert len(ops) == 1
 
-        print("Circuit:\n", cirq_device_1_wire.circuit)
-
         assert np.allclose(ops[0]._gate._matrix, np.array(U), **tol)
 
     # fmt: off
@@ -250,8 +248,6 @@ class TestOperations:
         ops = list(cirq_device_2_wires.circuit.all_operations())
 
         assert len(ops) == 1
-
-        print("Circuit:\n", cirq_device_2_wires.circuit)
 
         assert np.allclose(ops[0]._gate._matrix, np.array(U), **tol)
 
@@ -298,23 +294,43 @@ class TestOperations:
             ("PauliX", [], [cirq.X]),
             ("PauliY", [], [cirq.Y]),
             ("PauliZ", [], [cirq.Z]),
+            ("PauliX.inv", [], [cirq.X ** -1]),
+            ("PauliY.inv", [], [cirq.Y ** -1]),
+            ("PauliZ.inv", [], [cirq.Z ** -1]),
             ("Hadamard", [], [cirq.H]),
+            ("Hadamard.inv", [], [cirq.H ** -1]),
             ("S", [], [cirq.S]),
+            ("S.inv", [], [cirq.S ** -1]),
             ("PhaseShift", [1.4], [cirq.ZPowGate(exponent=1.4 / np.pi)]),
             ("PhaseShift", [-1.2], [cirq.ZPowGate(exponent=-1.2 / np.pi)]),
             ("PhaseShift", [2], [cirq.ZPowGate(exponent=2 / np.pi)]),
+            ("PhaseShift.inv", [1.4], [cirq.ZPowGate(exponent=-1.4 / np.pi)]),
+            ("PhaseShift.inv", [-1.2], [cirq.ZPowGate(exponent=1.2 / np.pi)]),
+            ("PhaseShift.inv", [2], [cirq.ZPowGate(exponent=-2 / np.pi)]),
             ("RX", [1.4], [cirq.Rx(1.4)]),
             ("RX", [-1.2], [cirq.Rx(-1.2)]),
             ("RX", [2], [cirq.Rx(2)]),
+            ("RX.inv", [1.4], [cirq.Rx(-1.4)]),
+            ("RX.inv", [-1.2], [cirq.Rx(1.2)]),
+            ("RX.inv", [2], [cirq.Rx(-2)]),
             ("RY", [1.4], [cirq.Ry(1.4)]),
             ("RY", [0], [cirq.Ry(0)]),
             ("RY", [-1.3], [cirq.Ry(-1.3)]),
+            ("RY.inv", [1.4], [cirq.Ry(-1.4)]),
+            ("RY.inv", [0], [cirq.Ry(0)]),
+            ("RY.inv", [-1.3], [cirq.Ry(+1.3)]),
             ("RZ", [1.4], [cirq.Rz(1.4)]),
             ("RZ", [-1.1], [cirq.Rz(-1.1)]),
             ("RZ", [1], [cirq.Rz(1)]),
+            ("RZ.inv", [1.4], [cirq.Rz(-1.4)]),
+            ("RZ.inv", [-1.1], [cirq.Rz(1.1)]),
+            ("RZ.inv", [1], [cirq.Rz(-1)]),
             ("Rot", [1.4, 2.3, -1.2], [cirq.Rz(1.4), cirq.Ry(2.3), cirq.Rz(-1.2)]),
             ("Rot", [1, 2, -1], [cirq.Rz(1), cirq.Ry(2), cirq.Rz(-1)]),
             ("Rot", [-1.1, 0.2, -1], [cirq.Rz(-1.1), cirq.Ry(0.2), cirq.Rz(-1)]),
+            ("Rot.inv", [1.4, 2.3, -1.2], [cirq.Rz(1.2), cirq.Ry(-2.3), cirq.Rz(-1.4)]),
+            ("Rot.inv", [1, 2, -1], [cirq.Rz(1), cirq.Ry(-2), cirq.Rz(-1)]),
+            ("Rot.inv", [-1.1, 0.2, -1], [cirq.Rz(1), cirq.Ry(-0.2), cirq.Rz(1.1)]),
             (
                 "QubitUnitary",
                 [np.array([[1, 0], [0, 1]])],

--- a/tests/test_cirq_device.py
+++ b/tests/test_cirq_device.py
@@ -106,23 +106,6 @@ def cirq_device_3_wires(shots):
 
 
 @pytest.mark.parametrize("shots", [100])
-class TestProperties:
-    """Tests that the properties of the CirqDevice are correctly implemented."""
-
-    def test_operations(self, cirq_device_1_wire):
-        """Tests that the CirqDevice supports all expected operations"""
-
-        assert cirq_device_1_wire.operations.issuperset(qml.ops.qubit.ops)
-
-        # TODO add cirq specific operations here.
-
-    def test_observables(self, cirq_device_1_wire):
-        """Tests that the CirqDevice supports all expected observables"""
-
-        assert cirq_device_1_wire.observables.issuperset(qml.ops.qubit.obs)
-
-
-@pytest.mark.parametrize("shots", [100])
 class TestOperations:
     """Tests that the CirqDevice correctly handles the requested operations."""
 

--- a/tests/test_cirq_interface.py
+++ b/tests/test_cirq_interface.py
@@ -97,6 +97,27 @@ class TestCirqOperation:
 
         assert not operation.is_inverse
 
+    def test_inv_apply(self):
+        """Tests that the operations in the queue are correctly applied if the 
+        CirqOperation is inverted."""
+
+        operation = CirqOperation(
+            lambda a, b, c: [cirq.X, cirq.Ry(a), cirq.Rx(b), cirq.Z, cirq.Rz(c)]
+        )
+        operation.inv()
+
+        operation.parametrize(0.1, 0.2, 0.3)
+
+        qubit = cirq.LineQubit(1)
+
+        gate_applications = list(operation.apply(qubit))
+
+        assert gate_applications[0] == cirq.Rz(-0.3).on(qubit)
+        assert gate_applications[1] == (cirq.Z**-1).on(qubit)
+        assert gate_applications[2] == cirq.Rx(-0.2).on(qubit)
+        assert gate_applications[3] == cirq.Ry(-0.1).on(qubit)
+        assert gate_applications[4] == (cirq.X**-1).on(qubit)
+
 
 class TestMethods:
     """Tests the independent methods in the Cirq interface."""

--- a/tests/test_cirq_interface.py
+++ b/tests/test_cirq_interface.py
@@ -127,7 +127,7 @@ class TestCirqOperation:
         operation.parametrize(0.1, 0.2, 0.3)
 
         with pytest.raises(
-            qml.DeviceError, match="CirqOperation must be inverted before it is parametrized"
+            qml.DeviceError, match="CirqOperation can't be inverted after it was parametrized"
         ):
             operation.inv()
 

--- a/tests/test_cirq_interface.py
+++ b/tests/test_cirq_interface.py
@@ -33,6 +33,7 @@ class TestCirqOperation:
 
         assert operation.parametrized_cirq_gates is None
         assert operation.parametrization == fun
+        assert not operation.is_inverse
 
     def test_parametrize(self):
         """Tests that parametrize yields the correct queue of operations."""
@@ -78,6 +79,23 @@ class TestCirqOperation:
             qml.DeviceError, match="CirqOperation must be parametrized before it can be applied."
         ):
             operation.apply(qubit)
+
+    def test_inv(self):
+        """Test that inv inverts the gate and applying inv twice yields the initial state."""
+
+        operation = CirqOperation(
+            lambda a, b, c: [cirq.X, cirq.Ry(a), cirq.Rx(b), cirq.Z, cirq.Rz(c)]
+        )
+
+        assert not operation.is_inverse
+
+        operation.inv()
+
+        assert operation.is_inverse
+
+        operation.inv()
+
+        assert not operation.is_inverse
 
 
 class TestMethods:

--- a/tests/test_cirq_interface.py
+++ b/tests/test_cirq_interface.py
@@ -118,6 +118,17 @@ class TestCirqOperation:
         assert gate_applications[3] == cirq.Ry(-0.1).on(qubit)
         assert gate_applications[4] == (cirq.X**-1).on(qubit)
 
+    def test_inv_error(self):
+        """Test that inv raises an error if the CirqOperation was already parametrized."""
+
+        operation = CirqOperation(
+            lambda a, b, c: [cirq.X, cirq.Ry(a), cirq.Rx(b), cirq.Z, cirq.Rz(c)]
+        )
+        operation.parametrize(0.1, 0.2, 0.3)
+
+        with pytest.raises(qml.DeviceError, match="CirqOperation must be inverted before it is parametrized"):
+            operation.inv()
+
 
 class TestMethods:
     """Tests the independent methods in the Cirq interface."""

--- a/tests/test_cirq_interface.py
+++ b/tests/test_cirq_interface.py
@@ -113,10 +113,10 @@ class TestCirqOperation:
         gate_applications = list(operation.apply(qubit))
 
         assert gate_applications[0] == cirq.Rz(-0.3).on(qubit)
-        assert gate_applications[1] == (cirq.Z**-1).on(qubit)
+        assert gate_applications[1] == (cirq.Z ** -1).on(qubit)
         assert gate_applications[2] == cirq.Rx(-0.2).on(qubit)
         assert gate_applications[3] == cirq.Ry(-0.1).on(qubit)
-        assert gate_applications[4] == (cirq.X**-1).on(qubit)
+        assert gate_applications[4] == (cirq.X ** -1).on(qubit)
 
     def test_inv_error(self):
         """Test that inv raises an error if the CirqOperation was already parametrized."""
@@ -126,7 +126,9 @@ class TestCirqOperation:
         )
         operation.parametrize(0.1, 0.2, 0.3)
 
-        with pytest.raises(qml.DeviceError, match="CirqOperation must be inverted before it is parametrized"):
+        with pytest.raises(
+            qml.DeviceError, match="CirqOperation must be inverted before it is parametrized"
+        ):
             operation.inv()
 
 


### PR DESCRIPTION
This PR adds support to inverse operations to Pennylane-Cirq.

To achieve this, the class `CirqOperation` got a new method `.inv()` which uses `cirq.inverse`. All inverse operations are added to an `_inverse_operation_map` during init and apply just accesses `_complete_operation_map = _operation_map + _inverse_operation_map`.