### PR TITLE
Bumped version number to 0.2.0

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,12 +1,10 @@
-# Release 0.2.0-dev
+# Release 0.2.0
 
 ### New features since last release
 
-### Breaking changes
-
-### Improvements
-
-### Documentation
+* Adds support for inverse operations specified via the PennyLane
+  frontend UI.
+  [#14](https://github.com/XanaduAI/pennylane-cirq/pull/14)
 
 ### Bug fixes
 

--- a/pennylane_cirq/_version.py
+++ b/pennylane_cirq/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.2.0-dev"
+__version__ = "0.2.0"

--- a/pennylane_cirq/cirq_device.py
+++ b/pennylane_cirq/cirq_device.py
@@ -55,7 +55,7 @@ class CirqDevice(Device):
     """
 
     name = "Cirq Abstract PennyLane plugin baseclass"
-    pennylane_requires = ">=0.6.0"
+    pennylane_requires = ">=0.7.0"
     version = __version__
     author = "Johannes Jakob Meyer"
     _capabilities = {"model": "qubit", "tensor_observables": False, "inverse_operations": True}


### PR DESCRIPTION
* Bumps version number to 0.2
* Bumps `pennylane_requires` to `>=0.7.0`, since inverse operations were only introduced in v0.7