### PR TITLE
Include test case for Cirq v0.6 and v0.7 as well

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 import numpy as np
 import pytest
+from packaging import version
 
+from cirq import __version__
 from pennylane_cirq import SimulatorDevice
 
 
@@ -100,3 +102,15 @@ def device(request, shots, analytic):
             return device(wires=n, shots=shots)
 
     return _device
+
+@pytest.fixture
+def run_only_for_cirq_v0_6():
+    """Fixture to run a test case only for when Cirq version 0.6.0 is installed."""
+    if version.parse(__version__) !=  version.parse("0.6.0"):
+        pytest.skip("This test is only ran for Cirq version 0.6.0.")
+
+@pytest.fixture
+def run_only_for_cirq_v0_7_and_above():
+    """Fixture to run a test case only for when Cirq version 0.7.0 or higher is installed."""
+    if version.parse(__version__) < version.parse("0.7.0"):
+        pytest.skip("This test is only ran for Cirq version 0.7.0 and above.")

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -222,7 +222,19 @@ class TestStateApply:
         expected = np.abs(mat @ state) ** 2
         assert np.allclose(res, expected, **tol)
 
-    def test_invalid_qubit_state_unitary(self, device):
+    @pytest.mark.usefixtures("run_only_for_cirq_v0_6")
+    def test_invalid_qubit_state_unitary_cirq_v0_6(self, device):
+        """Test that an exception is raised if the
+        unitary matrix is the wrong size"""
+        dev = device(2)
+        state = np.array([[0, 123.432], [-0.432, 023.4]])
+
+        with pytest.raises(ValueError, match=r"Not a 2x2 .* unitary matrix"):
+            with mimic_execution_for_apply(dev):
+                dev.apply("QubitUnitary", [0, 1], [state])
+
+    @pytest.mark.usefixtures("run_only_for_cirq_v0_7_and_above")
+    def test_invalid_qubit_state_unitary_cirq_v0_7_and_above(self, device):
         """Test that an exception is raised if the
         unitary matrix is the wrong size"""
         dev = device(2)


### PR DESCRIPTION
**Context**
A test case in `test_apply` output different messages with Cirq version `0.6` and `0.7`.

**Description of Change**
This PR creates fixtures for these two cases, such that the version number of the Cirq package can remain as is in the `requirements.txt` file.

It basically includes both the old and new test message from #18 and skips exactly one of them based on the Cirq version.

**Benefits**
This way, the test suite will pass with both `cirq==0.6` and `cirq>=0.7`.

**Drawbacks**
Branching off for a test case might be unfavourable.