### PR TITLE
Increasing the version number to 0.8.0

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug fixes
 
-* Fix minor bug introduced into the test suite by the release of Cirq 0.7.0.
+* Fix a minor bug introduced into the test suite by the release of Cirq 0.7.0.
   [#18](https://github.com/XanaduAI/pennylane-cirq/pull/18)
 
 * Fix bugs introduced into the test suite by the release of Cirq 0.6.0.

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,16 +1,17 @@
-# Release 0.2.0-dev
-
-### New features since last release
-
-### Breaking changes
+# Release 0.8.0
 
 ### Improvements
 
-### Documentation
+* Added support for inverse operations by defining the `.inv()` method
+  of the `CirqOperation` class which uses the `cirq.inverse` function.
+  [#15](https://github.com/XanaduAI/pennylane-cirq/pull/15)
 
 ### Bug fixes
 
-* Fix bugs introduces into the test suite by the release of Cirq 0.6.0
+* Fix minor bug introduced into the test suite by the release of Cirq 0.7.0.
+  [#18](https://github.com/XanaduAI/pennylane-cirq/pull/18)
+
+* Fix bugs introduced into the test suite by the release of Cirq 0.6.0.
   [#13](https://github.com/XanaduAI/pennylane-cirq/pull/13)
 
 ### Contributors

--- a/pennylane_cirq/_version.py
+++ b/pennylane_cirq/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.2.0-dev"
+__version__ = "0.8.0"

--- a/pennylane_cirq/cirq_device.py
+++ b/pennylane_cirq/cirq_device.py
@@ -47,9 +47,9 @@ class CirqDevice(Device):
     Args:
         wires (int): the number of modes to initialize the device in
         shots (int): Number of circuit evaluations/random samples used
-            to estimate expectation values of observables. Shots need 
+            to estimate expectation values of observables. Shots need
             to >= 1.
-        qubits (List[cirq.Qubit]): a list of Cirq qubits that are used 
+        qubits (List[cirq.Qubit]): a list of Cirq qubits that are used
             as wires. The wire number corresponds to the index in the list.
             By default, an array of `cirq.LineQubit` instances is created.
     """

--- a/pennylane_cirq/cirq_device.py
+++ b/pennylane_cirq/cirq_device.py
@@ -69,7 +69,7 @@ class CirqDevice(Device):
         Args:
             measurements (np.array[bool]): the measurements as boolean values
             eigenvalues (np.array[float]): eigenvalues corresponding to the observed basis states
-        
+
         Returns:
             (np.array[float]): the converted measurements
         """

--- a/pennylane_cirq/cirq_device.py
+++ b/pennylane_cirq/cirq_device.py
@@ -55,7 +55,7 @@ class CirqDevice(Device):
     """
 
     name = "Cirq Abstract PennyLane plugin baseclass"
-    pennylane_requires = ">=0.6.0"
+    pennylane_requires = ">=0.7.0"
     version = __version__
     author = "Johannes Jakob Meyer"
     _capabilities = {"model": "qubit", "tensor_observables": False, "inverse_operations": True}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pennylane>=0.6
+pennylane>=0.7
 cirq>=0.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pennylane>=0.7
 cirq>=0.7
+numpy~=1.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pennylane>=0.7
-cirq>=0.6
+cirq>=0.7


### PR DESCRIPTION
The following changes were carried out in this PR:
* Increase version number in CHANGELOG
* Update the PR list  in CHANGELOG
* Increase version in `_version.py`
* Increment `pennylane_requires` for the device and in `requirements.txt` since inverses have been added in PennyLane `v0.7` (therefore almost the entire test suite now fails with `v0.6`.