### PR TITLE
Rename probability to analytic_probability

### DIFF
--- a/pennylane_cirq/simulator_device.py
+++ b/pennylane_cirq/simulator_device.py
@@ -142,7 +142,7 @@ class SimulatorDevice(CirqDevice):
 
             self._state = np.array(self._result.state_vector())
 
-    def probability(self, wires=None):
+    def analytic_probability(self, wires=None):
         # pylint: disable=missing-function-docstring
         if self._state is None:
             return None

--- a/tests/test_simulator_device.py
+++ b/tests/test_simulator_device.py
@@ -532,6 +532,17 @@ class TestStatePreparationErrorsNonAnalytic:
                 [qml.QubitStateVector(np.array([0, 1]), wires=[0])]
             )
 
+@pytest.mark.parametrize("shots,analytic", [(100, True)])
+class TestAnalyticProbability:
+    """Tests the analytic_probability method works as expected."""
+
+    def test_analytic_probability_is_none(self, simulator_device_1_wire):
+        """Tests that analytic_probability returns None if the state of the
+        device is None."""
+
+        simulator_device_1_wire.reset()
+        assert simulator_device_1_wire._state is None
+        assert simulator_device_1_wire.analytic_probability() is None
 
 @pytest.mark.parametrize("shots,analytic", [(100, True)])
 class TestExpval:


### PR DESCRIPTION
This change follows-up the change in the structure of `QubitDevice`:
https://github.com/XanaduAI/pennylane/pull/573