### PR TITLE
Adding Cirq DensityMatrixSimulator device

### DIFF
--- a/doc/devices/mixed_simulator.rst
+++ b/doc/devices/mixed_simulator.rst
@@ -1,7 +1,7 @@
-The Mixed Simulator device
+The Mixed Simulator Device
 ==========================
 
-You can instantiate the device in PennyLane as follows:
+You can instantiate the mixed-state simulator device in PennyLane as follows:
 
 .. code-block:: python
 
@@ -10,24 +10,27 @@ You can instantiate the device in PennyLane as follows:
     dev = qml.device('cirq.mixedsimulator', wires=2)
 
 This device can then be used just like other devices for the definition and evaluation of QNodes within PennyLane.
-A simple quantum function that returns the expectation value of a measurement and depends on three classical input
-parameters would look like:
+Unlike the ``cirq.simulator`` backend, this device also supports several of Cirq's custom non-unitary channels,
+e.g., ``BitFlip`` or ``Depolarize``.
 
 .. code-block:: python
 
+    from pennylane_cirq import ops
+
     @qml.qnode(dev)
-    def circuit(x, y, z):
-        qml.RZ(z, wires=[0])
-        qml.RY(y, wires=[0])
+    def circuit(x, p, q):
         qml.RX(x, wires=[0])
+        ops.BitFlip(p, wires=[0])
+        ops.Depolarize(q, wires=[1])
         qml.CNOT(wires=[0, 1])
         return qml.expval(qml.PauliZ(wires=1))
 
-You can then execute the circuit like any other function to get the quantum mechanical expectation value.
-
-.. code-block:: python
-
     circuit(0.2, 0.1, 0.3)
+
+This device stores the internal state of the quantum simulation as a density matrix.
+This has additional memory overhead compared to pure-state simulation, but allows for
+additional channels to be performed. The density matrix can be accessed after a circuit
+execution using ``dev.state``.
 
 Device options
 ~~~~~~~~~~~~~~
@@ -47,17 +50,18 @@ qubits and give them to the device as a list.
       cirq.GridQubit(1, 1),
     ]
 
-    dev = qml.device("cirq.simulator", wires=4, qubits=qubits)
+    dev = qml.device("cirq.mixedsimulator", wires=4, qubits=qubits)
 
-The wire of each qubit corresponds to its index in the `qubit` list. In the above example,
-the wire 2 corresponds to `cirq.GridQubit(1, 0)`.
+The wire of each qubit corresponds to its index in the ``qubit`` list. In the above example,
+the wire 2 corresponds to ``cirq.GridQubit(1, 0)``.
 
 If no qubits are given, the plugin will create an array of ``LineQubit`` instances.
 
 Supported operations
 ~~~~~~~~~~~~~~~~~~~~
 
-The ``cirq.simulator`` device supports all PennyLane
+The ``cirq.mixedsimulator`` device supports all PennyLane
 `operations and observables <https://pennylane.readthedocs.io/en/stable/introduction/operations.html>`_.
 
-In the future, the device will also support all Cirq operations.
+It also supports the following non-unitary channels from Cirq (found in ``pennylane_cirq.ops``):
+``BitFlip``, ``PhaseFlip``, ``PhaseDamp``, ``AmplitudeDamp``, and ``Depolarize``.

--- a/doc/devices/mixed_simulator.rst
+++ b/doc/devices/mixed_simulator.rst
@@ -64,4 +64,5 @@ The ``cirq.mixedsimulator`` device supports all PennyLane
 `operations and observables <https://pennylane.readthedocs.io/en/stable/introduction/operations.html>`_.
 
 It also supports the following non-unitary channels from Cirq (found in ``pennylane_cirq.ops``):
-``BitFlip``, ``PhaseFlip``, ``PhaseDamp``, ``AmplitudeDamp``, and ``Depolarize``.
+:class:`~.BitFlip`, :class:`~.PhaseFlip`, :class:`~.PhaseDamp`,
+:class:`~.AmplitudeDamp`, and :class:`~.Depolarize`.

--- a/doc/devices/mixed_simulator.rst
+++ b/doc/devices/mixed_simulator.rst
@@ -32,7 +32,7 @@ You can then execute the circuit like any other function to get the quantum mech
 Device options
 ~~~~~~~~~~~~~~
 
-Cirq has different ways of defining qubits, e.g. `LineQubit` or `GridQubit`. The Cirq device therefore accepts
+Cirq has different ways of defining qubits, e.g., ``LineQubit`` or ``GridQubit``. The Cirq device therefore accepts
 an additional argument ``qubits=None`` that you can use to define your own
 qubits and give them to the device as a list.
 
@@ -52,7 +52,7 @@ qubits and give them to the device as a list.
 The wire of each qubit corresponds to its index in the `qubit` list. In the above example,
 the wire 2 corresponds to `cirq.GridQubit(1, 0)`.
 
-If no qubits are given, the plugin will create an array of `LineQubit` instances.
+If no qubits are given, the plugin will create an array of ``LineQubit`` instances.
 
 Supported operations
 ~~~~~~~~~~~~~~~~~~~~

--- a/doc/devices/mixed_simulator.rst
+++ b/doc/devices/mixed_simulator.rst
@@ -1,0 +1,63 @@
+The Mixed Simulator device
+==========================
+
+You can instantiate the device in PennyLane as follows:
+
+.. code-block:: python
+
+    import pennylane as qml
+
+    dev = qml.device('cirq.mixedsimulator', wires=2)
+
+This device can then be used just like other devices for the definition and evaluation of QNodes within PennyLane.
+A simple quantum function that returns the expectation value of a measurement and depends on three classical input
+parameters would look like:
+
+.. code-block:: python
+
+    @qml.qnode(dev)
+    def circuit(x, y, z):
+        qml.RZ(z, wires=[0])
+        qml.RY(y, wires=[0])
+        qml.RX(x, wires=[0])
+        qml.CNOT(wires=[0, 1])
+        return qml.expval(qml.PauliZ(wires=1))
+
+You can then execute the circuit like any other function to get the quantum mechanical expectation value.
+
+.. code-block:: python
+
+    circuit(0.2, 0.1, 0.3)
+
+Device options
+~~~~~~~~~~~~~~
+
+Cirq has different ways of defining qubits, e.g. `LineQubit` or `GridQubit`. The Cirq device therefore accepts
+an additional argument ``qubits=None`` that you can use to define your own
+qubits and give them to the device as a list.
+
+.. code-block:: python
+
+    import cirq
+
+    qubits = [
+      cirq.GridQubit(0, 0),
+      cirq.GridQubit(0, 1),
+      cirq.GridQubit(1, 0),
+      cirq.GridQubit(1, 1),
+    ]
+
+    dev = qml.device("cirq.simulator", wires=4, qubits=qubits)
+
+The wire of each qubit corresponds to its index in the `qubit` list. In the above example,
+the wire 2 corresponds to `cirq.GridQubit(1, 0)`.
+
+If no qubits are given, the plugin will create an array of `LineQubit` instances.
+
+Supported operations
+~~~~~~~~~~~~~~~~~~~~
+
+The ``cirq.simulator`` device supports all PennyLane
+`operations and observables <https://pennylane.readthedocs.io/en/stable/introduction/operations.html>`_.
+
+In the future, the device will also support all Cirq operations.

--- a/doc/devices/simulator.rst
+++ b/doc/devices/simulator.rst
@@ -32,7 +32,7 @@ You can then execute the circuit like any other function to get the quantum mech
 Device options
 ~~~~~~~~~~~~~~
 
-Cirq has different ways of defining qubits, e.g. `LineQubit` or `GridQubit`. The Cirq device therefore accepts
+Cirq has different ways of defining qubits, e.g., ``LineQubit`` or ``GridQubit``. The Cirq device therefore accepts
 an additional argument ``qubits=None`` that you can use to define your own
 qubits and give them to the device as a list.
 
@@ -49,10 +49,10 @@ qubits and give them to the device as a list.
 
     dev = qml.device("cirq.simulator", wires=4, qubits=qubits)
 
-The wire of each qubit corresponds to its index in the `qubit` list. In the above example,
-the wire 2 corresponds to `cirq.GridQubit(1, 0)`.
+The wire of each qubit corresponds to its index in the ``qubit`` list. In the above example,
+the wire 2 corresponds to ``cirq.GridQubit(1, 0)``.
 
-If no qubits are given, the plugin will create an array of `LineQubit` instances.
+If no qubits are given, the plugin will create an array of ``LineQubit`` instances.
 
 Supported operations
 ~~~~~~~~~~~~~~~~~~~~

--- a/doc/devices/simulator.rst
+++ b/doc/devices/simulator.rst
@@ -59,5 +59,3 @@ Supported operations
 
 The ``cirq.simulator`` device supports all PennyLane
 `operations and observables <https://pennylane.readthedocs.io/en/stable/introduction/operations.html>`_.
-
-In the future, the device will also support all Cirq operations.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -20,13 +20,18 @@ away in PennyLane, without the need to import any additional packages.
 Devices
 ~~~~~~~
 
-Currently, PennyLane-Cirq provides one Cirq device for PennyLane:
+Currently, PennyLane-Cirq provides two Cirq devices for PennyLane:
 
 .. devicegalleryitem::
     :name: 'cirq.simulator'
     :description: Cirq's simulator backend.
     :link: devices/simulator.html
 
+.. devicegalleryitem::
+    :name: 'cirq.mixedsimulator'
+    :description: Cirq's density matrix simulator backend.
+    :link: devices/mixed_simulator.html
+ 
 .. raw:: html
 
         <div style='clear:both'></div>

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -64,6 +64,7 @@ and simply replace ``'default.qubit'`` with the ``'cirq.simulator'`` device:
    :hidden:
 
    devices/simulator
+   devices/mixed_simulator
 
 .. toctree::
    :maxdepth: 1

--- a/pennylane_cirq/__init__.py
+++ b/pennylane_cirq/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Xanadu Quantum Technologies Inc.
+# Copyright 2019-2020 Xanadu Quantum Technologies Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pennylane_cirq/__init__.py
+++ b/pennylane_cirq/__init__.py
@@ -15,8 +15,9 @@
 Plugin overview
 ===============
 """
-from .simulator_device import SimulatorDevice
+from .simulator_device import SimulatorDevice, MixedStateSimulatorDevice
 
 # TODO[CUSTOM OPS]: Uncomment and import all custom gates
 # from .ops import S, T, CCNOT, CPHASE, CSWAP, ISWAP, PSWAP
+from .ops import BitFlip
 from ._version import __version__

--- a/pennylane_cirq/__init__.py
+++ b/pennylane_cirq/__init__.py
@@ -17,7 +17,5 @@ Plugin overview
 """
 from .simulator_device import SimulatorDevice, MixedStateSimulatorDevice
 
-# TODO[CUSTOM OPS]: Uncomment and import all custom gates
-# from .ops import S, T, CCNOT, CPHASE, CSWAP, ISWAP, PSWAP
 from .ops import BitFlip, PhaseFlip, PhaseDamp, AmplitudeDamp, Depolarize
 from ._version import __version__

--- a/pennylane_cirq/__init__.py
+++ b/pennylane_cirq/__init__.py
@@ -19,5 +19,5 @@ from .simulator_device import SimulatorDevice, MixedStateSimulatorDevice
 
 # TODO[CUSTOM OPS]: Uncomment and import all custom gates
 # from .ops import S, T, CCNOT, CPHASE, CSWAP, ISWAP, PSWAP
-from .ops import BitFlip
+from .ops import BitFlip, PhaseFlip, PhaseDamp, AmplitudeDamp, Depolarize
 from ._version import __version__

--- a/pennylane_cirq/cirq_device.py
+++ b/pennylane_cirq/cirq_device.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Xanadu Quantum Technologies Inc.
+# Copyright 2019-2020 Xanadu Quantum Technologies Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ from pennylane import QubitDevice
 from pennylane.operation import Operation
 
 from ._version import __version__
-from .cirq_interface import CirqOperation
+from .cirq_operation import CirqOperation
 
 
 class CirqDevice(QubitDevice, abc.ABC):

--- a/pennylane_cirq/cirq_device.py
+++ b/pennylane_cirq/cirq_device.py
@@ -41,6 +41,7 @@ from pennylane.operation import Operation
 from ._version import __version__
 from .cirq_interface import CirqOperation
 
+
 class CirqDevice(QubitDevice, abc.ABC):
     """Abstract base device for PennyLane-Cirq.
 
@@ -56,7 +57,7 @@ class CirqDevice(QubitDevice, abc.ABC):
     name = "Cirq Abstract PennyLane plugin baseclass"
     pennylane_requires = ">=0.8.0"
     version = __version__
-    author = "Johannes Jakob Meyer"
+    author = "Xanadu Inc"
     _capabilities = {
         "model": "qubit",
         "tensor_observables": True,
@@ -92,9 +93,7 @@ class CirqDevice(QubitDevice, abc.ABC):
             inverted_operation = CirqOperation(self._operation_map[key].parametrization)
             inverted_operation.inv()
 
-            self._inverse_operation_map[
-                key + Operation.string_for_inverse
-            ] = inverted_operation
+            self._inverse_operation_map[key + Operation.string_for_inverse] = inverted_operation
 
         self._complete_operation_map = {
             **self._operation_map,
@@ -195,9 +194,7 @@ class CirqDevice(QubitDevice, abc.ABC):
             cirq_operation.parametrize(*operation.parameters)
 
             self.circuit.append(
-                cirq_operation.apply(
-                    *[self.qubits[wire] for wire in operation.wires]
-                )
+                cirq_operation.apply(*[self.qubits[wire] for wire in operation.wires])
             )
 
     def apply(self, operations, **kwargs):
@@ -207,7 +204,9 @@ class CirqDevice(QubitDevice, abc.ABC):
         for i, operation in enumerate(operations):
             if i > 0 and operation.name in {"BasisState", "QubitStateVector"}:
                 raise qml.DeviceError(
-                    "The operation {} is only supported at the beginning of a circuit.".format(operation.name)
+                    "The operation {} is only supported at the beginning of a circuit.".format(
+                        operation.name
+                    )
                 )
 
             if operation.name == "BasisState":

--- a/pennylane_cirq/cirq_interface.py
+++ b/pennylane_cirq/cirq_interface.py
@@ -12,25 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Base Cirq device class
-===========================
+Cirq Operation class
+====================
 
 **Module name:** :mod:`pennylane_cirq.cirq_interface`
 
 .. currentmodule:: pennylane_cirq.cirq_interface
 
-An abstract base class for constructing Cirq devices for PennyLane.
-
-This should contain all the boilerplate for supporting PennyLane
-from Cirq, making it easier to create new devices.
-The abstract base class below should contain all common code required
-by Cirq.
-
-This abstract base class will not be used by the user. Add/delete
-methods and attributes below where needed.
-
-See https://pennylane.readthedocs.io/en/latest/API/overview.html
-for an overview of how the Device class works.
+An helper class that wraps the native Cirq operations and provides an interface for PennyLane.
 
 Classes
 -------
@@ -84,14 +73,9 @@ class CirqOperation:
             *qubits (Cirq:Qid): the qubits on which the Cirq gates should be performed.
         """
         if not self.parametrized_cirq_gates:
-            raise qml.DeviceError(
-                "CirqOperation must be parametrized before it can be applied."
-            )
+            raise qml.DeviceError("CirqOperation must be parametrized before it can be applied.")
 
-        return (
-            parametrized_gate(*qubits)
-            for parametrized_gate in self.parametrized_cirq_gates
-        )
+        return (parametrized_gate(*qubits) for parametrized_gate in self.parametrized_cirq_gates)
 
     def inv(self):
         """Inverses the CirqOperation."""
@@ -99,8 +83,6 @@ class CirqOperation:
         # PennyLane-Cirq codebase at the moment.
 
         if self.parametrized_cirq_gates:
-            raise qml.DeviceError(
-                "CirqOperation can't be inverted after it was parametrized."
-            )
+            raise qml.DeviceError("CirqOperation can't be inverted after it was parametrized.")
 
         self.is_inverse = not self.is_inverse

--- a/pennylane_cirq/cirq_operation.py
+++ b/pennylane_cirq/cirq_operation.py
@@ -36,7 +36,7 @@ import pennylane as qml
 
 
 class CirqOperation:
-    """A helper class that wraps the native Cirq operations and provides an 
+    """A helper class that wraps the native Cirq operations and provides an
        interface for parametrization and application."""
 
     def __init__(self, parametrization):
@@ -44,7 +44,7 @@ class CirqOperation:
 
         Args:
             parametrization (Tuple[float] -> Union[Cirq:Qid, List[Cirq:Qid]]): Converts the PennyLane gate parameters to an ordered list of gates
-              that are to be applied            
+              that are to be applied
         """
 
         self.parametrization = parametrization

--- a/pennylane_cirq/cirq_operation.py
+++ b/pennylane_cirq/cirq_operation.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Xanadu Quantum Technologies Inc.
+# Copyright 2019-2020 Xanadu Quantum Technologies Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
 Cirq Operation class
 ====================
 
-**Module name:** :mod:`pennylane_cirq.cirq_interface`
+**Module name:** :mod:`pennylane_cirq.cirq_operation`
 
-.. currentmodule:: pennylane_cirq.cirq_interface
+.. currentmodule:: pennylane_cirq.cirq_operation
 
 An helper class that wraps the native Cirq operations and provides an interface for PennyLane.
 

--- a/pennylane_cirq/ops.py
+++ b/pennylane_cirq/ops.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Xanadu Quantum Technologies Inc.
+# Copyright 2019-2020 Xanadu Quantum Technologies Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pennylane_cirq/ops.py
+++ b/pennylane_cirq/ops.py
@@ -40,10 +40,11 @@ Operations
 ----------
 
 .. autosummary::
-    S
-    T
-    CCNOT
-    CSWAP
+    BitFlip
+    PhaseFlip
+    PhaseDamp
+    AmplitudeDamp
+    Depolarize
 
 
 Code details
@@ -53,6 +54,11 @@ from pennylane.operation import Operation, AnyWires
 
 
 class BitFlip(Operation):
+    """Cirq ``bit_flip`` operation.
+
+    See the `Cirq docs <https://cirq.readthedocs.io/en/stable/generated/cirq.bit_flip.html>`_
+    for further details."""
+
     num_params = 1
     num_wires = 1
     par_domain = "R"
@@ -62,6 +68,11 @@ class BitFlip(Operation):
 
 
 class PhaseFlip(Operation):
+    """Cirq ``phase_flip`` operation.
+
+    See the `Cirq docs <https://cirq.readthedocs.io/en/stable/generated/cirq.phase_flip.html>`_
+    for further details."""
+
     num_params = 1
     num_wires = 1
     par_domain = "R"
@@ -71,6 +82,11 @@ class PhaseFlip(Operation):
 
 
 class PhaseDamp(Operation):
+    """Cirq ``phase_damp`` operation.
+
+    See the `Cirq docs <https://cirq.readthedocs.io/en/stable/generated/cirq.phase_damp.html>`_
+    for further details."""
+
     num_params = 1
     num_wires = 1
     par_domain = "R"
@@ -80,6 +96,11 @@ class PhaseDamp(Operation):
 
 
 class AmplitudeDamp(Operation):
+    """Cirq ``amplitude_damp`` operation.
+
+    See the `Cirq docs <https://cirq.readthedocs.io/en/stable/generated/cirq.amplitude_damp.html>`_
+    for further details."""
+
     num_params = 1
     num_wires = 1
     par_domain = "R"
@@ -89,6 +110,11 @@ class AmplitudeDamp(Operation):
 
 
 class Depolarize(Operation):
+    """Cirq ``depolarize`` operation.
+
+    See the `Cirq docs <https://cirq.readthedocs.io/en/stable/generated/cirq.depolarize.html>`_
+    for further details."""
+
     num_params = 1
     num_wires = 1
     par_domain = "R"

--- a/pennylane_cirq/ops.py
+++ b/pennylane_cirq/ops.py
@@ -56,8 +56,8 @@ from pennylane.operation import Operation, AnyWires
 class BitFlip(Operation):
     num_params = 1
     num_wires = 1
-    par_domain = 'R'
-    
+    par_domain = "R"
+
     grad_method = None
     grad_recipe = None
 
@@ -65,7 +65,7 @@ class BitFlip(Operation):
 class PhaseFlip(Operation):
     num_params = 1
     num_wires = 1
-    par_domain = 'R'
+    par_domain = "R"
 
     grad_method = None
     grad_recipe = None
@@ -74,7 +74,7 @@ class PhaseFlip(Operation):
 class PhaseDamp(Operation):
     num_params = 1
     num_wires = 1
-    par_domain = 'R'
+    par_domain = "R"
 
     grad_method = None
     grad_recipe = None
@@ -83,7 +83,7 @@ class PhaseDamp(Operation):
 class AmplitudeDamp(Operation):
     num_params = 1
     num_wires = 1
-    par_domain = 'R'
+    par_domain = "R"
 
     grad_method = None
     grad_recipe = None
@@ -92,105 +92,7 @@ class AmplitudeDamp(Operation):
 class Depolarize(Operation):
     num_params = 1
     num_wires = 1
-    par_domain = 'R'
+    par_domain = "R"
 
     grad_method = None
     grad_recipe = None
-
-
-# class S(Operation):
-#     r"""S(wires)
-#     S gate.
-
-#     .. math:: S = \begin{bmatrix} 1 & 0 \\ 0 & i \end{bmatrix}
-
-#     **Details:**
-
-#     * Number of wires: 1
-#     * Number of parameters: 0
-
-#     Args:
-#         wires (int): the subsystem the gate acts on
-#     """
-#     num_params = 0
-#     num_wires = 1
-#     par_domain = None
-
-
-# class T(Operation):
-#     r"""T(wires)
-#     T gate.
-
-#     .. math:: T = \begin{bmatrix}1&0\\0&e^{i \pi / 4}\end{bmatrix}
-
-#     **Details:**
-
-#     * Number of wires: 1
-#     * Number of parameters: 0
-
-#     Args:
-#         wires (int): the subsystem the gate acts on
-#     """
-#     num_params = 0
-#     num_wires = 1
-#     par_domain = None
-
-
-# class CCNOT(Operation):
-#     r"""CCNOT(wires)
-#     Controlled-controlled-not gate.
-
-#     .. math::
-
-#         CCNOT = \begin{bmatrix}
-#             1 & 0 & 0 & 0 & 0 & 0 & 0 & 0 \\
-#             0 & 1 & 0 & 0 & 0 & 0 & 0 & 0 \\
-#             0 & 0 & 1 & 0 & 0 & 0 & 0 & 0 \\
-#             0 & 0 & 0 & 1 & 0 & 0 & 0 & 0 \\
-#             0 & 0 & 0 & 0 & 1 & 0 & 0 & 0 \\
-#             0 & 0 & 0 & 0 & 0 & 1 & 0 & 0 \\
-#             0 & 0 & 0 & 0 & 0 & 0 & 0 & 1 \\
-#             0 & 0 & 0 & 0 & 0 & 0 & 1 & 0
-#         \end{bmatrix}
-
-#     **Details:**
-
-#     * Number of wires: 3
-#     * Number of parameters: 0
-
-#     Args:
-#         wires (int): the subsystem the gate acts on
-#     """
-#     num_params = 0
-#     num_wires = 3
-#     par_domain = None
-
-
-# class CSWAP(Operation):
-#     r"""CSWAP(wires)
-#     Controlled-swap gate.
-
-#     .. math::
-
-#         CSWAP = \begin{bmatrix}
-#             1 & 0 & 0 & 0 & 0 & 0 & 0 & 0 \\
-#              0 & 1 & 0 & 0 & 0 & 0 & 0 & 0 \\
-#              0 & 0 & 1 & 0 & 0 & 0 & 0 & 0 \\
-#              0 & 0 & 0 & 1 & 0 & 0 & 0 & 0 \\
-#              0 & 0 & 0 & 0 & 1 & 0 & 0 & 0 \\
-#              0 & 0 & 0 & 0 & 0 & 0 & 1 & 0 \\
-#              0 & 0 & 0 & 0 & 0 & 1 & 0 & 0 \\
-#              0 & 0 & 0 & 0 & 0 & 0 & 0 & 1
-#         \end{bmatrix}
-
-#     **Details:**
-
-#     * Number of wires: 3
-#     * Number of parameters: 0
-
-#     Args:
-#         wires (int): the subsystem the gate acts on
-#     """
-#     num_params = 0
-#     num_wires = 3
-#     par_domain = None

--- a/pennylane_cirq/ops.py
+++ b/pennylane_cirq/ops.py
@@ -63,7 +63,7 @@ class BitFlip(Operation):
     
     @staticmethod
     def _matrix(*params):
-        return None
+        raise NotImplementedError
 
 # class S(Operation):
 #     r"""S(wires)

--- a/pennylane_cirq/ops.py
+++ b/pennylane_cirq/ops.py
@@ -60,10 +60,25 @@ class BitFlip(Operation):
     
     grad_method = None
     grad_recipe = None
-    
-    @staticmethod
-    def _matrix(*params):
-        raise NotImplementedError
+
+
+class PhaseFlip(Operation):
+    num_params = 1
+    num_wires = 1
+    par_domain = 'R'
+
+    grad_method = None
+    grad_recipe = None
+
+
+class PhaseDamp(Operation):
+    num_params = 1
+    num_wires = 1
+    par_domain = 'R'
+
+    grad_method = None
+    grad_recipe = None
+
 
 # class S(Operation):
 #     r"""S(wires)

--- a/pennylane_cirq/ops.py
+++ b/pennylane_cirq/ops.py
@@ -50,7 +50,7 @@ Code details
 ~~~~~~~~~~~~
 """
 # TODO[CUSTOM OPS]: Uncomment and replace with Cirq-specific ops
-from pennylane.operation import Operation
+from pennylane.operation import Operation, AnyWires
 
 
 class BitFlip(Operation):
@@ -72,6 +72,24 @@ class PhaseFlip(Operation):
 
 
 class PhaseDamp(Operation):
+    num_params = 1
+    num_wires = 1
+    par_domain = 'R'
+
+    grad_method = None
+    grad_recipe = None
+
+
+class AmplitudeDamp(Operation):
+    num_params = 1
+    num_wires = 1
+    par_domain = 'R'
+
+    grad_method = None
+    grad_recipe = None
+
+
+class Depolarize(Operation):
     num_params = 1
     num_wires = 1
     par_domain = 'R'

--- a/pennylane_cirq/ops.py
+++ b/pennylane_cirq/ops.py
@@ -50,8 +50,20 @@ Code details
 ~~~~~~~~~~~~
 """
 # TODO[CUSTOM OPS]: Uncomment and replace with Cirq-specific ops
-# from pennylane.operation import Operation
+from pennylane.operation import Operation
 
+
+class BitFlip(Operation):
+    num_params = 1
+    num_wires = 1
+    par_domain = 'R'
+    
+    grad_method = None
+    grad_recipe = None
+    
+    @staticmethod
+    def _matrix(*params):
+        return None
 
 # class S(Operation):
 #     r"""S(wires)

--- a/pennylane_cirq/ops.py
+++ b/pennylane_cirq/ops.py
@@ -50,8 +50,9 @@ Operations
 Code details
 ~~~~~~~~~~~~
 """
-from pennylane.operation import Operation, AnyWires
+from pennylane.operation import Operation
 
+# pylint: disable=missing-function-docstring
 
 class BitFlip(Operation):
     """Cirq ``bit_flip`` operation.

--- a/pennylane_cirq/ops.py
+++ b/pennylane_cirq/ops.py
@@ -49,7 +49,6 @@ Operations
 Code details
 ~~~~~~~~~~~~
 """
-# TODO[CUSTOM OPS]: Uncomment and replace with Cirq-specific ops
 from pennylane.operation import Operation, AnyWires
 
 

--- a/pennylane_cirq/simulator_device.py
+++ b/pennylane_cirq/simulator_device.py
@@ -216,6 +216,8 @@ class MixedStateSimulatorDevice(SimulatorDevice):
         "BitFlip": CirqOperation(cirq.bit_flip),
         "PhaseFlip": CirqOperation(cirq.phase_flip),
         "PhaseDamp": CirqOperation(cirq.phase_damp),
+        "AmplitudeDamp": CirqOperation(cirq.amplitude_damp),
+        "Depolarize": CirqOperation(cirq.depolarize),
     }
 
     def __init__(self, wires, shots=1000, analytic=True, qubits=None):

--- a/pennylane_cirq/simulator_device.py
+++ b/pennylane_cirq/simulator_device.py
@@ -53,7 +53,7 @@ class SimulatorDevice(CirqDevice):
             be calculated analytically. Defaults to ``True``. 
         qubits (List[cirq.Qubit]): a list of Cirq qubits that are used 
             as wires. The wire number corresponds to the index in the list.
-            By default, an array of `cirq.LineQubit` instances is created.
+            By default, an array of ``cirq.LineQubit`` instances is created.
     """
     name = "Cirq Simulator device for PennyLane"
     short_name = "cirq.simulator"

--- a/pennylane_cirq/simulator_device.py
+++ b/pennylane_cirq/simulator_device.py
@@ -39,6 +39,7 @@ import pennylane as qml
 from .cirq_device import CirqDevice
 from .cirq_interface import CirqOperation
 
+
 class SimulatorDevice(CirqDevice):
     r"""Cirq simulator device for PennyLane.
 
@@ -77,9 +78,7 @@ class SimulatorDevice(CirqDevice):
     def _apply_basis_state(self, basis_state_operation):
         # pylint: disable=missing-function-docstring
         if not self.analytic:
-            raise qml.DeviceError(
-                "The operation BasisState is only supported in analytic mode."
-            )
+            raise qml.DeviceError("The operation BasisState is only supported in analytic mode.")
 
         basis_state_array = np.array(basis_state_operation.parameters[0])
 
@@ -108,9 +107,7 @@ class SimulatorDevice(CirqDevice):
                 "The operation QubitStateVector is only supported in analytic mode."
             )
 
-        state_vector = np.array(
-            qubit_state_vector_operation.parameters[0], dtype=np.complex64
-        )
+        state_vector = np.array(qubit_state_vector_operation.parameters[0], dtype=np.complex64)
 
         if len(state_vector) != 2 ** len(self.qubits):
             raise qml.DeviceError(
@@ -138,9 +135,7 @@ class SimulatorDevice(CirqDevice):
         self.circuit.append(cirq.IdentityGate(len(self.qubits))(*self.qubits))
 
         if self.analytic:
-            self._result = self._simulator.simulate(
-                self.circuit, initial_state=self._initial_state
-            )
+            self._result = self._simulator.simulate(self.circuit, initial_state=self._initial_state)
 
             self._state = self._get_state_from_cirq(self._result)
 
@@ -187,10 +182,7 @@ class SimulatorDevice(CirqDevice):
         # Bring measurements to a more managable form, but keep True/False as values for now
         # They will be changed in the measurement routines where the observable is available
         return np.array(
-            [
-                self._result.measurements[str(wire)].flatten()
-                for wire in range(self.num_wires)
-            ]
+            [self._result.measurements[str(wire)].flatten() for wire in range(self.num_wires)]
         ).T.astype(int)
 
 

--- a/pennylane_cirq/simulator_device.py
+++ b/pennylane_cirq/simulator_device.py
@@ -50,7 +50,7 @@ class SimulatorDevice(CirqDevice):
             to >= 1. In analytic mode, shots indicates the number of entries
             that are returned by ``device.sample``.
         analytic (bool): Indicates that expectation values and variances should
-            be calculated analytically. Defaults to `True`. 
+            be calculated analytically. Defaults to ``True``. 
         qubits (List[cirq.Qubit]): a list of Cirq qubits that are used 
             as wires. The wire number corresponds to the index in the list.
             By default, an array of `cirq.LineQubit` instances is created.
@@ -196,10 +196,10 @@ class MixedStateSimulatorDevice(SimulatorDevice):
             to >= 1. In analytic mode, shots indicates the number of entries
             that are returned by device.sample.
         analytic (bool): Indicates that expectation values and variances should
-            be calculated analytically. Defaults to `True`.
+            be calculated analytically. Defaults to ``True``.
         qubits (List[cirq.Qubit]): a list of Cirq qubits that are used
             as wires. The wire number corresponds to the index in the list.
-            By default, an array of `cirq.LineQubit` instances is created.
+            By default, an array of ``cirq.LineQubit`` instances is created.
     """
     name = "Cirq Mixed-State Simulator device for PennyLane"
     short_name = "cirq.mixedsimulator"

--- a/pennylane_cirq/simulator_device.py
+++ b/pennylane_cirq/simulator_device.py
@@ -46,12 +46,12 @@ class SimulatorDevice(CirqDevice):
     Args:
         wires (int): the number of modes to initialize the device in
         shots (int): Number of circuit evaluations/random samples used
-            to estimate expectation values of observables. Shots need 
+            to estimate expectation values of observables. Shots need
             to >= 1. In analytic mode, shots indicates the number of entries
             that are returned by ``device.sample``.
         analytic (bool): Indicates that expectation values and variances should
-            be calculated analytically. Defaults to ``True``. 
-        qubits (List[cirq.Qubit]): a list of Cirq qubits that are used 
+            be calculated analytically. Defaults to ``True``.
+        qubits (List[cirq.Qubit]): a list of Cirq qubits that are used
             as wires. The wire number corresponds to the index in the list.
             By default, an array of ``cirq.LineQubit`` instances is created.
     """
@@ -163,7 +163,7 @@ class SimulatorDevice(CirqDevice):
 
         .. note::
 
-            The state includes possible basis rotations for non-diagonal 
+            The state includes possible basis rotations for non-diagonal
             observables. Note that this behaviour differs from PennyLane's
             default.qubit plugin.
         """

--- a/pennylane_cirq/simulator_device.py
+++ b/pennylane_cirq/simulator_device.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """
 Cirq Simulator Devices
-========
+======================
 
 **Module name:** :mod:`pennylane_cirq.simulator_device`
 
@@ -37,7 +37,7 @@ import numpy as np
 import pennylane as qml
 
 from .cirq_device import CirqDevice
-from .cirq_interface import CirqOperation
+from .cirq_operation import CirqOperation
 
 
 class SimulatorDevice(CirqDevice):
@@ -48,7 +48,7 @@ class SimulatorDevice(CirqDevice):
         shots (int): Number of circuit evaluations/random samples used
             to estimate expectation values of observables. Shots need 
             to >= 1. In analytic mode, shots indicates the number of entries
-            that are returned by device.sample.
+            that are returned by ``device.sample``.
         analytic (bool): Indicates that expectation values and variances should
             be calculated analytically. Defaults to `True`. 
         qubits (List[cirq.Qubit]): a list of Cirq qubits that are used 
@@ -136,7 +136,6 @@ class SimulatorDevice(CirqDevice):
 
         if self.analytic:
             self._result = self._simulator.simulate(self.circuit, initial_state=self._initial_state)
-
             self._state = self._get_state_from_cirq(self._result)
 
     def analytic_probability(self, wires=None):
@@ -149,7 +148,8 @@ class SimulatorDevice(CirqDevice):
 
         return self.marginal_prob(probs, wires)
 
-    def _get_state_from_cirq(self, result):
+    @staticmethod
+    def _get_state_from_cirq(result):
         """Extract the state array from a Cirq TrialResult ``result``"""
         return np.array(result.state_vector())
 
@@ -235,7 +235,8 @@ class MixedStateSimulatorDevice(SimulatorDevice):
         dim = 2 ** self.num_wires
         return np.kron(state_vec, state_vec.conj()).reshape((dim, dim))
 
-    def _get_state_from_cirq(self, result):
+    @staticmethod
+    def _get_state_from_cirq(result):
         """Extract the state array from a Cirq TrialResult"""
         return np.array(result.final_density_matrix)
 

--- a/pennylane_cirq/simulator_device.py
+++ b/pennylane_cirq/simulator_device.py
@@ -154,11 +154,11 @@ class SimulatorDevice(CirqDevice):
         return self.marginal_prob(probs, wires)
 
     def _get_state_from_cirq(self, result):
-        """Helper function to extract the state array from a Cirq TrialResult ``result``"""
+        """Extract the state array from a Cirq TrialResult ``result``"""
         return np.array(result.state_vector())
 
     def _get_computational_basis_probs(self):
-        """Helper function to extract the probabilities of all computational basis measurements."""
+        """Extract the probabilities of all computational basis measurements."""
         return np.abs(self._state) ** 2
 
     @property
@@ -234,16 +234,16 @@ class MixedStateSimulatorDevice(SimulatorDevice):
         self._initial_state = self._convert_to_density_matrix(self._initial_state)
 
     def _convert_to_density_matrix(self, state_vec):
-        """Helper function to convert ``state_vec`` into a density matrix."""
+        """Convert ``state_vec`` into a density matrix."""
         dim = 2 ** self.num_wires
         return np.kron(state_vec, state_vec.conj()).reshape((dim, dim))
 
     def _get_state_from_cirq(self, result):
-        """Helper function to extract the state array from a Cirq TrialResult"""
+        """Extract the state array from a Cirq TrialResult"""
         return np.array(result.final_density_matrix)
 
     def _get_computational_basis_probs(self):
-        """Helper function to extract the probabilities of all computational basis measurements."""
+        """Extract the probabilities of all computational basis measurements."""
         return np.diag(self._state).real
 
     @property

--- a/pennylane_cirq/simulator_device.py
+++ b/pennylane_cirq/simulator_device.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Cirq Simulator Device
+Cirq Simulator Devices
 ========
 
 **Module name:** :mod:`pennylane_cirq.simulator_device`
@@ -20,13 +20,14 @@ Cirq Simulator Device
 .. currentmodule:: pennylane_cirq.simulator_device
 
 This Device implements all the :class:`~pennylane.device.Device` methods,
-for using Cirq simulator as a PennyLane device.
+for using Cirq simulators as PennyLane device.
 
 Classes
 -------
 
 .. autosummary::
    SimulatorDevice
+   MixedStateSimulatorDevice
 
 ----
 """
@@ -213,6 +214,8 @@ class MixedStateSimulatorDevice(SimulatorDevice):
 
     _mixed_sim_operation_map = {
         "BitFlip": CirqOperation(cirq.bit_flip),
+        "PhaseFlip": CirqOperation(cirq.phase_flip),
+        "PhaseDamp": CirqOperation(cirq.phase_damp),
     }
 
     def __init__(self, wires, shots=1000, analytic=True, qubits=None):

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Xanadu Quantum Technologies Inc.
+# Copyright 2019-2020 Xanadu Quantum Technologies Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ info = {
     "url": "http://xanadu.ai",
     "license": "Apache License 2.0",
     "packages": ["pennylane_cirq"],
-    "entry_points": {"pennylane.plugins": ["cirq.simulator = pennylane_cirq:SimulatorDevice"]},
+    "entry_points": {"pennylane.plugins": ["cirq.simulator = pennylane_cirq:SimulatorDevice",
+                                           "cirq.mixedsimulator = pennylane_cirq:MixedStateSimulatorDevice"],},
     # Place a one line description here. This will be shown by pip
     "description": "PennyLane plugin for Cirq",
     "long_description": open("README.rst").read(),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@
 import numpy as np
 import pytest
 
-from pennylane_cirq import SimulatorDevice
+from pennylane_cirq import SimulatorDevice, MixedStateSimulatorDevice
 
 
 np.random.seed(42)
@@ -55,7 +55,7 @@ B = np.array(
 
 # List of all devices that support analytic expectation value
 # computation. This generally includes statevector/wavefunction simulators.
-analytic_devices = [SimulatorDevice]
+analytic_devices = [SimulatorDevice, MixedStateSimulatorDevice]
 
 # List of all devices that do *not* support analytic expectation
 # value computation. This generally includes hardware devices

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,9 +35,7 @@ U = np.array(
 U2 = np.array([[0, 1, 1, 1], [1, 0, 1, -1], [1, -1, 0, 1], [1, 1, -1, 0]]) / np.sqrt(3)
 
 # single qubit Hermitian observable
-A = np.array(
-    [[1.02789352, 1.61296440 - 0.3498192j], [1.61296440 + 0.3498192j, 1.23920938 + 0j]]
-)
+A = np.array([[1.02789352, 1.61296440 - 0.3498192j], [1.61296440 + 0.3498192j, 1.23920938 + 0j]])
 
 # two-qubit Hermitian observable
 B = np.array(

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -152,10 +152,7 @@ class TestApplyPureState:
 
         with mimic_execution_for_apply(dev):
             dev.apply(
-                [
-                    qml.QubitStateVector(state, wires=[0]),
-                    qml.__getattribute__(name)(wires=[0]),
-                ]
+                [qml.QubitStateVector(state, wires=[0]), qml.__getattribute__(name)(wires=[0]),]
             )
 
         res = dev._state
@@ -191,9 +188,7 @@ class TestApplyPureState:
         c = -0.654
 
         with mimic_execution_for_apply(dev):
-            dev.apply(
-                [qml.QubitStateVector(state, wires=[0]), qml.Rot(a, b, c, wires=[0])]
-            )
+            dev.apply([qml.QubitStateVector(state, wires=[0]), qml.Rot(a, b, c, wires=[0])])
 
         res = dev._state
         expected = rot(a, b, c) @ state
@@ -350,10 +345,7 @@ class TestApplyMixedState:
 
         with mimic_execution_for_apply(dev):
             dev.apply(
-                [
-                    qml.QubitStateVector(state, wires=[0]),
-                    qml.__getattribute__(name)(wires=[0]),
-                ]
+                [qml.QubitStateVector(state, wires=[0]), qml.__getattribute__(name)(wires=[0]),]
             )
 
         res = dev._state
@@ -391,9 +383,7 @@ class TestApplyMixedState:
         c = -0.654
 
         with mimic_execution_for_apply(dev):
-            dev.apply(
-                [qml.QubitStateVector(state, wires=[0]), qml.Rot(a, b, c, wires=[0])]
-            )
+            dev.apply([qml.QubitStateVector(state, wires=[0]), qml.Rot(a, b, c, wires=[0])])
 
         res = dev._state
         expected = rot(a, b, c) @ state

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -16,6 +16,7 @@ import pytest
 
 import numpy as np
 import pennylane as qml
+from pennylane_cirq import SimulatorDevice, MixedStateSimulatorDevice
 from scipy.linalg import block_diag
 
 from conftest import U, U2, A
@@ -87,53 +88,53 @@ def mimic_execution_for_apply(device):
 
 
 @pytest.mark.parametrize("shots,analytic", [(1000, True)])
-class TestStateApply:
-    """Test application of PennyLane operations to state simulators."""
+class TestApplyPureState:
+    """Test application of PennyLane operations on the pure state simulator."""
 
-    def test_basis_state(self, device, tol):
+    def test_basis_state(self, analytic, shots, tol):
         """Test basis state initialization"""
-        dev = device(4)
+        dev = SimulatorDevice(4, analytic=analytic, shots=shots)
         state = np.array([0, 0, 1, 0])
 
         with mimic_execution_for_apply(dev):
             dev.apply([qml.BasisState(state, wires=[0, 1, 2, 3])])
 
-        res = np.abs(dev._state) ** 2
+        res = dev._state
 
         expected = np.zeros([2 ** 4])
         expected[np.ravel_multi_index(state, [2] * 4)] = 1
         assert np.allclose(res, expected, **tol)
 
-    def test_identity_basis_state(self, device, tol):
+    def test_identity_basis_state(self, analytic, shots, tol):
         """Test basis state initialization if identity"""
-        dev = device(4)
+        dev = SimulatorDevice(4, analytic=analytic, shots=shots)
         state = np.array([1, 0, 0, 0])
 
         with mimic_execution_for_apply(dev):
             dev.apply([qml.BasisState(state, wires=[0, 1, 2, 3])])
 
-        res = np.abs(dev._state) ** 2
+        res = dev._state
 
         expected = np.zeros([2 ** 4])
         expected[np.ravel_multi_index(state, [2] * 4)] = 1
         assert np.allclose(res, expected, **tol)
 
-    def test_qubit_state_vector(self, init_state, device, tol):
+    def test_qubit_state_vector(self, init_state, analytic, shots, tol):
         """Test PauliX application"""
-        dev = device(1)
+        dev = SimulatorDevice(1, analytic=analytic, shots=shots)
         state = init_state(1)
 
         with mimic_execution_for_apply(dev):
             dev.apply([qml.QubitStateVector(state, wires=[0])])
 
-        res = np.abs(dev._state) ** 2
-        expected = np.abs(state) ** 2
+        res = dev._state
+        expected = state
         assert np.allclose(res, expected, **tol)
 
-    def test_invalid_qubit_state_vector(self, device):
+    def test_invalid_qubit_state_vector(self, analytic, shots):
         """Test that an exception is raised if the state
         vector is the wrong size"""
-        dev = device(2)
+        dev = SimulatorDevice(2, analytic=analytic, shots=shots)
         state = np.array([0, 123.432])
 
         with pytest.raises(
@@ -144,9 +145,9 @@ class TestStateApply:
                 dev.apply([qml.QubitStateVector(state, wires=[0, 1])])
 
     @pytest.mark.parametrize("name,mat", single_qubit)
-    def test_single_qubit_no_parameters(self, init_state, device, name, mat, tol):
+    def test_single_qubit_no_parameters(self, init_state, analytic, shots, name, mat, tol):
         """Test application of single qubit gates without parameters"""
-        dev = device(1)
+        dev = SimulatorDevice(1, analytic=analytic, shots=shots)
         state = init_state(1)
 
         with mimic_execution_for_apply(dev):
@@ -157,15 +158,15 @@ class TestStateApply:
                 ]
             )
 
-        res = np.abs(dev._state) ** 2
-        expected = np.abs(mat @ state) ** 2
+        res = dev._state
+        expected = mat @ state
         assert np.allclose(res, expected, **tol)
 
     @pytest.mark.parametrize("theta", [0.5432, -0.232])
     @pytest.mark.parametrize("name,func", single_qubit_param)
-    def test_single_qubit_parameters(self, init_state, device, name, func, theta, tol):
-        """Test PauliX application"""
-        dev = device(1)
+    def test_single_qubit_parameters(self, init_state, analytic, shots, name, func, theta, tol):
+        """Test application of single qubit gates with parameters"""
+        dev = SimulatorDevice(1, analytic=analytic, shots=shots)
         state = init_state(1)
 
         with mimic_execution_for_apply(dev):
@@ -176,13 +177,13 @@ class TestStateApply:
                 ]
             )
 
-        res = np.abs(dev._state) ** 2
-        expected = np.abs(func(theta) @ state) ** 2
+        res = dev._state
+        expected = func(theta) @ state
         assert np.allclose(res, expected, **tol)
 
-    def test_rotation(self, init_state, device, tol):
+    def test_rotation(self, init_state, analytic, shots, tol):
         """Test three axis rotation gate"""
-        dev = device(1)
+        dev = SimulatorDevice(1, analytic=analytic, shots=shots)
         state = init_state(1)
 
         a = 0.542
@@ -194,14 +195,14 @@ class TestStateApply:
                 [qml.QubitStateVector(state, wires=[0]), qml.Rot(a, b, c, wires=[0])]
             )
 
-        res = np.abs(dev._state) ** 2
-        expected = np.abs(rot(a, b, c) @ state) ** 2
+        res = dev._state
+        expected = rot(a, b, c) @ state
         assert np.allclose(res, expected, **tol)
 
     @pytest.mark.parametrize("name,mat", two_qubit)
-    def test_two_qubit_no_parameters(self, init_state, device, name, mat, tol):
+    def test_two_qubit_no_parameters(self, init_state, analytic, shots, name, mat, tol):
         """Test PauliX application"""
-        dev = device(2)
+        dev = SimulatorDevice(2, analytic=analytic, shots=shots)
         state = init_state(2)
 
         with mimic_execution_for_apply(dev):
@@ -212,14 +213,14 @@ class TestStateApply:
                 ]
             )
 
-        res = np.abs(dev._state) ** 2
-        expected = np.abs(mat @ state) ** 2
+        res = dev._state
+        expected = mat @ state
         assert np.allclose(res, expected, **tol)
 
     @pytest.mark.parametrize("mat", [U, U2])
-    def test_qubit_unitary(self, init_state, device, mat, tol):
+    def test_qubit_unitary(self, init_state, analytic, shots, mat, tol):
         N = int(np.log2(len(mat)))
-        dev = device(N)
+        dev = SimulatorDevice(N, analytic=analytic, shots=shots)
         state = init_state(N)
 
         with mimic_execution_for_apply(dev):
@@ -230,14 +231,14 @@ class TestStateApply:
                 ]
             )
 
-        res = np.abs(dev._state) ** 2
-        expected = np.abs(mat @ state) ** 2
+        res = dev._state
+        expected = mat @ state
         assert np.allclose(res, expected, **tol)
 
-    def test_invalid_qubit_state_unitary(self, device):
+    def test_invalid_qubit_state_unitary(self, analytic, shots):
         """Test that an exception is raised if the
         unitary matrix is the wrong size"""
-        dev = device(2)
+        dev = SimulatorDevice(2, analytic=analytic, shots=shots)
         state = np.array([[0, 123.432], [-0.432, 023.4]])
 
         with pytest.raises(ValueError, match=r"Not a unitary matrix"):
@@ -245,8 +246,8 @@ class TestStateApply:
                 dev.apply([qml.QubitUnitary(state, wires=[0, 1])])
 
     @pytest.mark.parametrize("name, mat", three_qubit)
-    def test_three_qubit_no_parameters(self, init_state, device, name, mat, tol):
-        dev = device(3)
+    def test_three_qubit_no_parameters(self, init_state, analytic, shots, name, mat, tol):
+        dev = SimulatorDevice(3, analytic=analytic, shots=shots)
         state = init_state(3)
 
         with mimic_execution_for_apply(dev):
@@ -257,15 +258,15 @@ class TestStateApply:
                 ]
             )
 
-        res = np.abs(dev._state) ** 2
-        expected = np.abs(mat @ state) ** 2
+        res = dev._state
+        expected = mat @ state
         assert np.allclose(res, expected, **tol)
 
     @pytest.mark.parametrize("theta", [0.5432, -0.232])
     @pytest.mark.parametrize("name,func", two_qubit_param)
-    def test_single_qubit_parameters(self, init_state, device, name, func, theta, tol):
-        """Test PauliX application"""
-        dev = device(2)
+    def test_two_qubits_parameters(self, init_state, analytic, shots, name, func, theta, tol):
+        """Test application of two qubit gates with parameters"""
+        dev = SimulatorDevice(2, analytic=analytic, shots=shots)
         state = init_state(2)
 
         with mimic_execution_for_apply(dev):
@@ -276,71 +277,75 @@ class TestStateApply:
                 ]
             )
 
-        res = np.abs(dev._state) ** 2
-        expected = np.abs(func(theta) @ state) ** 2
+        res = dev._state
+        expected = func(theta) @ state
         assert np.allclose(res, expected, **tol)
 
 
-@pytest.mark.parametrize("shots,analytic", [(8192, True)])
-class RemoveThisWhenHardwareIsImplementedTestHardwareApply:
-    """Test application of PennyLane operations on hardware simulators."""
+@pytest.mark.parametrize("shots,analytic", [(1000, True)])
+class TestApplyMixedState:
+    """Test application of PennyLane operations on the mixed state simulator."""
 
-    def test_basis_state(self, device, tol):
+    def test_basis_state(self, analytic, shots, tol):
         """Test basis state initialization"""
-        dev = device(4)
+        dev = MixedStateSimulatorDevice(4, analytic=analytic, shots=shots)
         state = np.array([0, 0, 1, 0])
 
         with mimic_execution_for_apply(dev):
             dev.apply([qml.BasisState(state, wires=[0, 1, 2, 3])])
 
-        res = np.fromiter(dev.probabilities(wires=range(4)).values(), dtype=np.float64)
+        res = dev._state
 
-        expected = np.zeros([2 ** 4])
+        expected = np.zeros([16])
         expected[np.ravel_multi_index(state, [2] * 4)] = 1
+        expected = np.kron(expected, expected.conj()).reshape([2 ** 4, 2 ** 4])
         assert np.allclose(res, expected, **tol)
 
-    def test_basis_state_not_first_operation(self, device):
-        """Test that an exception is raised if BasisState is
-        applied to a circuit not in the ground state"""
-        dev = device(4)
-        state = np.array([0, 0, 1, 0])
+    def test_identity_basis_state(self, analytic, shots, tol):
+        """Test basis state initialization if identity"""
+        dev = MixedStateSimulatorDevice(4, analytic=analytic, shots=shots)
+        state = np.array([1, 0, 0, 0])
 
         with mimic_execution_for_apply(dev):
-            dev.apply([qml.Hadamard(wires=[0])])
+            dev.apply([qml.BasisState(state, wires=[0, 1, 2, 3])])
 
-            with pytest.raises(
-                qml.DeviceError, match="is only supported at the beginning of a circuit"
-            ):
-                dev.apply([qml.BasisState(state, wires=[0, 1, 2, 3])])
+        res = dev._state
 
-    def test_qubit_state_vector(self, init_state, device, tol):
+        expected = np.zeros([16])
+        expected[np.ravel_multi_index(state, [2] * 4)] = 1
+        expected = np.kron(expected, expected.conj()).reshape([16, 16])
+        assert np.allclose(res, expected, **tol)
+
+    def test_qubit_state_vector(self, init_state, analytic, shots, tol):
         """Test PauliX application"""
-        dev = device(1)
+        dev = MixedStateSimulatorDevice(1, analytic=analytic, shots=shots)
         state = init_state(1)
 
         with mimic_execution_for_apply(dev):
             dev.apply([qml.QubitStateVector(state, wires=[0])])
 
-        res = np.fromiter(dev.probabilities().values(), dtype=np.float64)
-        expected = np.abs(state) ** 2
+        res = dev._state
+        expected = state
+        expected = np.kron(state, state.conj()).reshape([2, 2])
         assert np.allclose(res, expected, **tol)
 
-    def test_invalid_qubit_state_vector(self, device):
+    def test_invalid_qubit_state_vector(self, analytic, shots):
         """Test that an exception is raised if the state
         vector is the wrong size"""
-        dev = device(2)
+        dev = MixedStateSimulatorDevice(2, analytic=analytic, shots=shots)
         state = np.array([0, 123.432])
 
         with pytest.raises(
-            ValueError, match=r"State vector must be of length 2\*\*wires"
+            qml.DeviceError,
+            match=r"For QubitStateVector, the state has to be specified for the correct number of qubits",
         ):
             with mimic_execution_for_apply(dev):
                 dev.apply([qml.QubitStateVector(state, wires=[0, 1])])
 
     @pytest.mark.parametrize("name,mat", single_qubit)
-    def test_single_qubit_no_parameters(self, init_state, device, name, mat, tol):
-        """Test PauliX application"""
-        dev = device(1)
+    def test_single_qubit_no_parameters(self, init_state, analytic, shots, name, mat, tol):
+        """Test application of single qubit gates without parameters"""
+        dev = MixedStateSimulatorDevice(1, analytic=analytic, shots=shots)
         state = init_state(1)
 
         with mimic_execution_for_apply(dev):
@@ -351,15 +356,16 @@ class RemoveThisWhenHardwareIsImplementedTestHardwareApply:
                 ]
             )
 
-        res = np.fromiter(dev.probabilities().values(), dtype=np.float64)
-        expected = np.abs(mat @ state) ** 2
+        res = dev._state
+        expected = mat @ state
+        expected = np.kron(expected, expected.conj()).reshape([2, 2])
         assert np.allclose(res, expected, **tol)
 
     @pytest.mark.parametrize("theta", [0.5432, -0.232])
     @pytest.mark.parametrize("name,func", single_qubit_param)
-    def test_single_qubit_parameters(self, init_state, device, name, func, theta, tol):
-        """Test PauliX application"""
-        dev = device(1)
+    def test_single_qubit_parameters(self, init_state, analytic, shots, name, func, theta, tol):
+        """Test application of single qubit gates with parameters"""
+        dev = MixedStateSimulatorDevice(1, analytic=analytic, shots=shots)
         state = init_state(1)
 
         with mimic_execution_for_apply(dev):
@@ -370,13 +376,14 @@ class RemoveThisWhenHardwareIsImplementedTestHardwareApply:
                 ]
             )
 
-        res = np.fromiter(dev.probabilities().values(), dtype=np.float64)
-        expected = np.abs(func(theta) @ state) ** 2
+        res = dev._state
+        expected = func(theta) @ state
+        expected = np.kron(expected, expected.conj()).reshape([2, 2])
         assert np.allclose(res, expected, **tol)
 
-    def test_rotation(self, init_state, device, tol):
+    def test_rotation(self, init_state, analytic, shots, tol):
         """Test three axis rotation gate"""
-        dev = device(1)
+        dev = MixedStateSimulatorDevice(1, analytic=analytic, shots=shots)
         state = init_state(1)
 
         a = 0.542
@@ -388,14 +395,15 @@ class RemoveThisWhenHardwareIsImplementedTestHardwareApply:
                 [qml.QubitStateVector(state, wires=[0]), qml.Rot(a, b, c, wires=[0])]
             )
 
-        res = np.fromiter(dev.probabilities().values(), dtype=np.float64)
-        expected = np.abs(rot(a, b, c) @ state) ** 2
+        res = dev._state
+        expected = rot(a, b, c) @ state
+        expected = np.kron(expected, expected.conj()).reshape([2, 2])
         assert np.allclose(res, expected, **tol)
 
     @pytest.mark.parametrize("name,mat", two_qubit)
-    def test_two_qubit_no_parameters(self, init_state, device, name, mat, tol):
+    def test_two_qubit_no_parameters(self, init_state, analytic, shots, name, mat, tol):
         """Test PauliX application"""
-        dev = device(2)
+        dev = MixedStateSimulatorDevice(2, analytic=analytic, shots=shots)
         state = init_state(2)
 
         with mimic_execution_for_apply(dev):
@@ -406,14 +414,15 @@ class RemoveThisWhenHardwareIsImplementedTestHardwareApply:
                 ]
             )
 
-        res = np.fromiter(dev.probabilities().values(), dtype=np.float64)
-        expected = np.abs(mat @ state) ** 2
+        res = dev._state
+        expected = mat @ state
+        expected = np.kron(expected, expected.conj()).reshape([4, 4])
         assert np.allclose(res, expected, **tol)
 
     @pytest.mark.parametrize("mat", [U, U2])
-    def test_qubit_unitary(self, init_state, device, mat, tol):
+    def test_qubit_unitary(self, init_state, analytic, shots, mat, tol):
         N = int(np.log2(len(mat)))
-        dev = device(N)
+        dev = MixedStateSimulatorDevice(N, analytic=analytic, shots=shots)
         state = init_state(N)
 
         with mimic_execution_for_apply(dev):
@@ -424,42 +433,44 @@ class RemoveThisWhenHardwareIsImplementedTestHardwareApply:
                 ]
             )
 
-        res = np.fromiter(dev.probabilities().values(), dtype=np.float64)
-        expected = np.abs(mat @ state) ** 2
+        res = dev._state
+        expected = mat @ state
+        expected = np.kron(expected, expected.conj()).reshape([2 ** N, 2 ** N])
         assert np.allclose(res, expected, **tol)
 
-    def test_invalid_qubit_state_unitary(self, device):
+    def test_invalid_qubit_state_unitary(self, analytic, shots):
         """Test that an exception is raised if the
         unitary matrix is the wrong size"""
-        dev = device(2)
+        dev = MixedStateSimulatorDevice(2, analytic=analytic, shots=shots)
         state = np.array([[0, 123.432], [-0.432, 023.4]])
 
-        with pytest.raises(ValueError, match=r"Unitary matrix must be of shape"):
+        with pytest.raises(ValueError, match=r"Not a unitary matrix"):
             with mimic_execution_for_apply(dev):
                 dev.apply([qml.QubitUnitary(state, wires=[0, 1])])
 
     @pytest.mark.parametrize("name, mat", three_qubit)
-    def test_three_qubit_no_parameters(self, init_state, device, name, mat, tol):
-        dev = device(3)
+    def test_three_qubit_no_parameters(self, init_state, analytic, shots, name, mat, tol):
+        dev = MixedStateSimulatorDevice(3, analytic=analytic, shots=shots)
         state = init_state(3)
 
         with mimic_execution_for_apply(dev):
             dev.apply(
                 [
                     qml.QubitStateVector(state, wires=[0, 1, 2]),
-                    qml.QubitUnitary(mat, wires=[0, 1, 2]),
+                    qml.__getattribute__(name)(wires=[0, 1, 2]),
                 ]
             )
 
-        res = np.fromiter(dev.probabilities().values(), dtype=np.float64)
-        expected = np.abs(mat @ state) ** 2
+        res = dev._state
+        expected = mat @ state
+        expected = np.kron(expected, expected.conj()).reshape([8, 8])
         assert np.allclose(res, expected, **tol)
 
     @pytest.mark.parametrize("theta", [0.5432, -0.232])
     @pytest.mark.parametrize("name,func", two_qubit_param)
-    def test_single_qubit_parameters(self, init_state, device, name, func, theta, tol):
-        """Test PauliX application"""
-        dev = device(2)
+    def test_two_qubits_parameters(self, init_state, analytic, shots, name, func, theta, tol):
+        """Test application of single qubit gates with parameters"""
+        dev = MixedStateSimulatorDevice(2, analytic=analytic, shots=shots)
         state = init_state(2)
 
         with mimic_execution_for_apply(dev):
@@ -470,6 +481,7 @@ class RemoveThisWhenHardwareIsImplementedTestHardwareApply:
                 ]
             )
 
-        res = np.fromiter(dev.probabilities().values(), dtype=np.float64)
-        expected = np.abs(func(theta) @ state) ** 2
+        res = dev._state
+        expected = func(theta) @ state
+        expected = np.kron(expected, expected.conj()).reshape([4, 4])
         assert np.allclose(res, expected, **tol)

--- a/tests/test_cirq_device.py
+++ b/tests/test_cirq_device.py
@@ -153,14 +153,8 @@ class TestOperations:
             (qml.PhaseShift(1.4, wires=[0]), [cirq.ZPowGate(exponent=1.4 / np.pi)]),
             (qml.PhaseShift(-1.2, wires=[0]), [cirq.ZPowGate(exponent=-1.2 / np.pi)]),
             (qml.PhaseShift(2, wires=[0]), [cirq.ZPowGate(exponent=2 / np.pi)]),
-            (
-                qml.PhaseShift(1.4, wires=[0]).inv(),
-                [cirq.ZPowGate(exponent=-1.4 / np.pi)],
-            ),
-            (
-                qml.PhaseShift(-1.2, wires=[0]).inv(),
-                [cirq.ZPowGate(exponent=1.2 / np.pi)],
-            ),
+            (qml.PhaseShift(1.4, wires=[0]).inv(), [cirq.ZPowGate(exponent=-1.4 / np.pi)],),
+            (qml.PhaseShift(-1.2, wires=[0]).inv(), [cirq.ZPowGate(exponent=1.2 / np.pi)],),
             (qml.PhaseShift(2, wires=[0]).inv(), [cirq.ZPowGate(exponent=-2 / np.pi)]),
             (qml.RX(1.4, wires=[0]), [cirq.rx(1.4)]),
             (qml.RX(-1.2, wires=[0]), [cirq.rx(-1.2)]),
@@ -180,27 +174,15 @@ class TestOperations:
             (qml.RZ(1.4, wires=[0]).inv(), [cirq.rz(-1.4)]),
             (qml.RZ(-1.1, wires=[0]).inv(), [cirq.rz(1.1)]),
             (qml.RZ(1, wires=[0]).inv(), [cirq.rz(-1)]),
-            (
-                qml.Rot(1.4, 2.3, -1.2, wires=[0]),
-                [cirq.rz(1.4), cirq.ry(2.3), cirq.rz(-1.2)],
-            ),
+            (qml.Rot(1.4, 2.3, -1.2, wires=[0]), [cirq.rz(1.4), cirq.ry(2.3), cirq.rz(-1.2)],),
             (qml.Rot(1, 2, -1, wires=[0]), [cirq.rz(1), cirq.ry(2), cirq.rz(-1)]),
-            (
-                qml.Rot(-1.1, 0.2, -1, wires=[0]),
-                [cirq.rz(-1.1), cirq.ry(0.2), cirq.rz(-1)],
-            ),
+            (qml.Rot(-1.1, 0.2, -1, wires=[0]), [cirq.rz(-1.1), cirq.ry(0.2), cirq.rz(-1)],),
             (
                 qml.Rot(1.4, 2.3, -1.2, wires=[0]).inv(),
                 [cirq.rz(1.2), cirq.ry(-2.3), cirq.rz(-1.4)],
             ),
-            (
-                qml.Rot(1, 2, -1, wires=[0]).inv(),
-                [cirq.rz(1), cirq.ry(-2), cirq.rz(-1)],
-            ),
-            (
-                qml.Rot(-1.1, 0.2, -1, wires=[0]).inv(),
-                [cirq.rz(1), cirq.ry(-0.2), cirq.rz(1.1)],
-            ),
+            (qml.Rot(1, 2, -1, wires=[0]).inv(), [cirq.rz(1), cirq.ry(-2), cirq.rz(-1)],),
+            (qml.Rot(-1.1, 0.2, -1, wires=[0]).inv(), [cirq.rz(1), cirq.ry(-0.2), cirq.rz(1.1)],),
             (
                 qml.QubitUnitary(np.array([[1, 0], [0, 1]]), wires=[0]),
                 [cirq.MatrixGate(np.array([[1, 0], [0, 1]]))],
@@ -222,9 +204,7 @@ class TestOperations:
                 [cirq.MatrixGate(np.array([[1, 0], [0, -1]])) ** -1],
             ),
             (
-                qml.QubitUnitary(
-                    np.array([[-1, 1], [1, 1]]) / math.sqrt(2), wires=[0]
-                ).inv(),
+                qml.QubitUnitary(np.array([[-1, 1], [1, 1]]) / math.sqrt(2), wires=[0]).inv(),
                 [cirq.MatrixGate(np.array([[-1, 1], [1, 1]]) / math.sqrt(2)) ** -1],
             ),
         ],
@@ -326,38 +306,23 @@ class TestOperations:
                 ),
                 [
                     cirq.MatrixGate(
-                        np.array(
-                            [[0, 0, 0, 1], [0, 0, 1, 0], [0, 1, 0, 0], [1, 0, 0, 0]]
-                        )
+                        np.array([[0, 0, 0, 1], [0, 0, 1, 0], [0, 1, 0, 0], [1, 0, 0, 0]])
                     )
                 ],
             ),
             (
                 qml.QubitUnitary(
-                    np.array(
-                        [[1, -1, -1, 1], [-1, -1, 1, 1], [-1, 1, -1, 1], [1, 1, 1, 1]]
-                    )
-                    / 2,
+                    np.array([[1, -1, -1, 1], [-1, -1, 1, 1], [-1, 1, -1, 1], [1, 1, 1, 1]]) / 2,
                     wires=[0, 1],
                 ),
                 [
                     cirq.MatrixGate(
-                        np.array(
-                            [
-                                [1, -1, -1, 1],
-                                [-1, -1, 1, 1],
-                                [-1, 1, -1, 1],
-                                [1, 1, 1, 1],
-                            ]
-                        )
+                        np.array([[1, -1, -1, 1], [-1, -1, 1, 1], [-1, 1, -1, 1], [1, 1, 1, 1],])
                         / 2
                     )
                 ],
             ),
-            (
-                qml.QubitUnitary(np.eye(4), wires=[0, 1]).inv(),
-                [cirq.MatrixGate(np.eye(4)) ** -1],
-            ),
+            (qml.QubitUnitary(np.eye(4), wires=[0, 1]).inv(), [cirq.MatrixGate(np.eye(4)) ** -1],),
             (
                 qml.QubitUnitary(
                     np.array([[0, 0, 0, 1], [0, 0, 1, 0], [0, 1, 0, 0], [1, 0, 0, 0]]),
@@ -365,31 +330,19 @@ class TestOperations:
                 ).inv(),
                 [
                     cirq.MatrixGate(
-                        np.array(
-                            [[0, 0, 0, 1], [0, 0, 1, 0], [0, 1, 0, 0], [1, 0, 0, 0]]
-                        )
+                        np.array([[0, 0, 0, 1], [0, 0, 1, 0], [0, 1, 0, 0], [1, 0, 0, 0]])
                     )
                     ** -1
                 ],
             ),
             (
                 qml.QubitUnitary(
-                    np.array(
-                        [[1, -1, -1, 1], [-1, -1, 1, 1], [-1, 1, -1, 1], [1, 1, 1, 1]]
-                    )
-                    / 2,
+                    np.array([[1, -1, -1, 1], [-1, -1, 1, 1], [-1, 1, -1, 1], [1, 1, 1, 1]]) / 2,
                     wires=[0, 1],
                 ).inv(),
                 [
                     cirq.MatrixGate(
-                        np.array(
-                            [
-                                [1, -1, -1, 1],
-                                [-1, -1, 1, 1],
-                                [-1, 1, -1, 1],
-                                [1, 1, 1, 1],
-                            ]
-                        )
+                        np.array([[1, -1, -1, 1], [-1, -1, 1, 1], [-1, 1, -1, 1], [1, 1, 1, 1],])
                         / 2
                     )
                     ** -1
@@ -410,4 +363,3 @@ class TestOperations:
 
         for i in range(len(ops)):
             assert ops[i].gate == expected_cirq_gates[i]
-

--- a/tests/test_cirq_device.py
+++ b/tests/test_cirq_device.py
@@ -411,24 +411,3 @@ class TestOperations:
         for i in range(len(ops)):
             assert ops[i].gate == expected_cirq_gates[i]
 
-    # @pytest.mark.parametrize("operation,par,expected_cirq_gates", [
-    #     ("BasisState", [[0]]),
-    #     ("BasisState", [[1]]),
-    #     ("QubitStateVector", [[1, 0]]),
-    #     ("QubitStateVector", [[0, 1]]),
-    #     ("QubitStateVector", [[1/math.sqrt(2), 1j/math.sqrt(2)]]),
-    #     ("QubitStateVector", [[1/2, math.sqrt(3)/2]]),
-    # ])
-    # def test_apply_state_preparations_single_wire(self, cirq_device_1_wire, operation, par, expected_cirq_gates):
-    #     """Tests that apply adds the correct gates to the circuit for state preparations."""
-
-    #     cirq_device_1_wire.reset()
-
-    #     cirq_device_1_wire.apply(operation, wires=[0], par=par)
-
-    #     ops = list(cirq_device_1_wire.circuit.all_operations())
-
-    #     assert len(ops) == len(expected_cirq_gates)
-
-    #     for i in range(len(ops)):
-    #         assert ops[i]._gate == expected_cirq_gates[i]

--- a/tests/test_cirq_interface.py
+++ b/tests/test_cirq_interface.py
@@ -76,8 +76,7 @@ class TestCirqOperation:
         qubit = cirq.LineQubit(1)
 
         with pytest.raises(
-            qml.DeviceError,
-            match="CirqOperation must be parametrized before it can be applied.",
+            qml.DeviceError, match="CirqOperation must be parametrized before it can be applied.",
         ):
             operation.apply(qubit)
 
@@ -128,7 +127,6 @@ class TestCirqOperation:
         operation.parametrize(0.1, 0.2, 0.3)
 
         with pytest.raises(
-            qml.DeviceError,
-            match="CirqOperation can't be inverted after it was parametrized",
+            qml.DeviceError, match="CirqOperation can't be inverted after it was parametrized",
         ):
             operation.inv()

--- a/tests/test_cirq_operation.py
+++ b/tests/test_cirq_operation.py
@@ -19,7 +19,7 @@ import pytest
 
 import pennylane as qml
 from pennylane import numpy as np
-from pennylane_cirq.cirq_interface import CirqOperation
+from pennylane_cirq.cirq_operation import CirqOperation
 
 
 class TestCirqOperation:

--- a/tests/test_expval.py
+++ b/tests/test_expval.py
@@ -48,11 +48,7 @@ class TestExpval:
 
         with mimic_execution_for_expval(dev):
             dev.apply(
-                [
-                    qml.RX(theta, wires=[0]),
-                    qml.RX(phi, wires=[1]),
-                    qml.CNOT(wires=[0, 1]),
-                ]
+                [qml.RX(theta, wires=[0]), qml.RX(phi, wires=[1]), qml.CNOT(wires=[0, 1]),]
             )
 
         O = qml.Identity
@@ -61,10 +57,7 @@ class TestExpval:
         dev._obs_queue = [O(wires=[0], do_queue=False), O(wires=[1], do_queue=False)]
 
         res = np.array(
-            [
-                dev.expval(O(wires=[0], do_queue=False)),
-                dev.expval(O(wires=[1], do_queue=False)),
-            ]
+            [dev.expval(O(wires=[0], do_queue=False)), dev.expval(O(wires=[1], do_queue=False)),]
         )
 
         assert np.allclose(res, np.array([1, 1]), **tol)
@@ -78,11 +71,7 @@ class TestExpval:
 
         with mimic_execution_for_expval(dev):
             dev.apply(
-                [
-                    qml.RX(theta, wires=[0]),
-                    qml.RX(phi, wires=[1]),
-                    qml.CNOT(wires=[0, 1]),
-                ]
+                [qml.RX(theta, wires=[0]), qml.RX(phi, wires=[1]), qml.CNOT(wires=[0, 1]),]
             )
 
         O = qml.PauliZ
@@ -91,15 +80,10 @@ class TestExpval:
         dev._obs_queue = [O(wires=[0], do_queue=False), O(wires=[1], do_queue=False)]
 
         res = np.array(
-            [
-                dev.expval(O(wires=[0], do_queue=False)),
-                dev.expval(O(wires=[1], do_queue=False)),
-            ]
+            [dev.expval(O(wires=[0], do_queue=False)), dev.expval(O(wires=[1], do_queue=False)),]
         )
 
-        assert np.allclose(
-            res, np.array([np.cos(theta), np.cos(theta) * np.cos(phi)]), **tol
-        )
+        assert np.allclose(res, np.array([np.cos(theta), np.cos(theta) * np.cos(phi)]), **tol)
 
     def test_paulix_expectation(self, device, shots, tol):
         """Test that PauliX expectation value is correct"""
@@ -111,11 +95,7 @@ class TestExpval:
 
         with mimic_execution_for_expval(dev):
             dev.apply(
-                [
-                    qml.RY(theta, wires=[0]),
-                    qml.RY(phi, wires=[1]),
-                    qml.CNOT(wires=[0, 1]),
-                ],
+                [qml.RY(theta, wires=[0]), qml.RY(phi, wires=[1]), qml.CNOT(wires=[0, 1]),],
                 rotations=O(wires=[0], do_queue=False).diagonalizing_gates()
                 + O(wires=[1], do_queue=False).diagonalizing_gates(),
             )
@@ -123,14 +103,9 @@ class TestExpval:
         dev._obs_queue = [O(wires=[0], do_queue=False), O(wires=[1], do_queue=False)]
 
         res = np.array(
-            [
-                dev.expval(O(wires=[0], do_queue=False)),
-                dev.expval(O(wires=[1], do_queue=False)),
-            ]
+            [dev.expval(O(wires=[0], do_queue=False)), dev.expval(O(wires=[1], do_queue=False)),]
         )
-        assert np.allclose(
-            res, np.array([np.sin(theta) * np.sin(phi), np.sin(phi)]), **tol
-        )
+        assert np.allclose(res, np.array([np.sin(theta) * np.sin(phi), np.sin(phi)]), **tol)
 
     def test_pauliy_expectation(self, device, shots, tol):
         """Test that PauliY expectation value is correct"""
@@ -142,11 +117,7 @@ class TestExpval:
 
         with mimic_execution_for_expval(dev):
             dev.apply(
-                [
-                    qml.RX(theta, wires=[0]),
-                    qml.RX(phi, wires=[1]),
-                    qml.CNOT(wires=[0, 1]),
-                ],
+                [qml.RX(theta, wires=[0]), qml.RX(phi, wires=[1]), qml.CNOT(wires=[0, 1]),],
                 rotations=O(wires=[0], do_queue=False).diagonalizing_gates()
                 + O(wires=[1], do_queue=False).diagonalizing_gates(),
             )
@@ -154,10 +125,7 @@ class TestExpval:
         dev._obs_queue = [O(wires=[0], do_queue=False), O(wires=[1], do_queue=False)]
 
         res = np.array(
-            [
-                dev.expval(O(wires=[0], do_queue=False)),
-                dev.expval(O(wires=[1], do_queue=False)),
-            ]
+            [dev.expval(O(wires=[0], do_queue=False)), dev.expval(O(wires=[1], do_queue=False)),]
         )
         assert np.allclose(res, np.array([0, -(np.cos(theta)) * np.sin(phi)]), **tol)
 
@@ -171,11 +139,7 @@ class TestExpval:
 
         with mimic_execution_for_expval(dev):
             dev.apply(
-                [
-                    qml.RY(theta, wires=[0]),
-                    qml.RY(phi, wires=[1]),
-                    qml.CNOT(wires=[0, 1]),
-                ],
+                [qml.RY(theta, wires=[0]), qml.RY(phi, wires=[1]), qml.CNOT(wires=[0, 1]),],
                 rotations=O(wires=[0], do_queue=False).diagonalizing_gates()
                 + O(wires=[1], do_queue=False).diagonalizing_gates(),
             )
@@ -183,10 +147,7 @@ class TestExpval:
         dev._obs_queue = [O(wires=[0], do_queue=False), O(wires=[1], do_queue=False)]
 
         res = np.array(
-            [
-                dev.expval(O(wires=[0], do_queue=False)),
-                dev.expval(O(wires=[1], do_queue=False)),
-            ]
+            [dev.expval(O(wires=[0], do_queue=False)), dev.expval(O(wires=[1], do_queue=False)),]
         )
         expected = np.array(
             [
@@ -206,11 +167,7 @@ class TestExpval:
 
         with mimic_execution_for_expval(dev):
             dev.apply(
-                [
-                    qml.RY(theta, wires=[0]),
-                    qml.RY(phi, wires=[1]),
-                    qml.CNOT(wires=[0, 1]),
-                ],
+                [qml.RY(theta, wires=[0]), qml.RY(phi, wires=[1]), qml.CNOT(wires=[0, 1]),],
                 rotations=O(A, wires=[0], do_queue=False).diagonalizing_gates()
                 + O(A, wires=[1], do_queue=False).diagonalizing_gates(),
             )
@@ -230,12 +187,8 @@ class TestExpval:
         a = A[0, 0]
         re_b = A[0, 1].real
         d = A[1, 1]
-        ev1 = (
-            (a - d) * np.cos(theta) + 2 * re_b * np.sin(theta) * np.sin(phi) + a + d
-        ) / 2
-        ev2 = (
-            (a - d) * np.cos(theta) * np.cos(phi) + 2 * re_b * np.sin(phi) + a + d
-        ) / 2
+        ev1 = ((a - d) * np.cos(theta) + 2 * re_b * np.sin(theta) * np.sin(phi) + a + d) / 2
+        ev2 = ((a - d) * np.cos(theta) * np.cos(phi) + 2 * re_b * np.sin(phi) + a + d) / 2
         expected = np.array([ev1, ev2])
 
         assert np.allclose(res, expected, **tol)
@@ -250,11 +203,7 @@ class TestExpval:
 
         with mimic_execution_for_expval(dev):
             dev.apply(
-                [
-                    qml.RY(theta, wires=[0]),
-                    qml.RY(phi, wires=[1]),
-                    qml.CNOT(wires=[0, 1]),
-                ],
+                [qml.RY(theta, wires=[0]), qml.RY(phi, wires=[1]), qml.CNOT(wires=[0, 1]),],
                 rotations=O(B, wires=[0, 1], do_queue=False).diagonalizing_gates(),
             )
 
@@ -287,9 +236,7 @@ class TestTensorExpval:
 
         dev = device(3)
 
-        obs = qml.PauliX(wires=[0], do_queue=False) @ qml.PauliY(
-            wires=[2], do_queue=False
-        )
+        obs = qml.PauliX(wires=[0], do_queue=False) @ qml.PauliY(wires=[2], do_queue=False)
 
         with mimic_execution_for_expval(dev):
             dev.apply(
@@ -335,9 +282,7 @@ class TestTensorExpval:
             )
 
         res = dev.expval(obs)
-        expected = -(
-            np.cos(varphi) * np.sin(phi) + np.sin(varphi) * np.cos(theta)
-        ) / np.sqrt(2)
+        expected = -(np.cos(varphi) * np.sin(phi) + np.sin(varphi) * np.cos(theta)) / np.sqrt(2)
 
         assert np.allclose(res, expected, **tol)
 
@@ -357,9 +302,7 @@ class TestTensorExpval:
                 [-5 - 2j, -5 - 4j, -4 - 3j, -6],
             ]
         )
-        obs = qml.PauliZ(wires=[0], do_queue=False) @ qml.Hermitian(
-            A, wires=[1, 2], do_queue=False
-        )
+        obs = qml.PauliZ(wires=[0], do_queue=False) @ qml.Hermitian(A, wires=[1, 2], do_queue=False)
 
         with mimic_execution_for_expval(dev):
             dev.apply(

--- a/tests/test_mixed_simulator_device.py
+++ b/tests/test_mixed_simulator_device.py
@@ -96,11 +96,9 @@ class TestApply:
         simulator_device_1_wire.apply([op(wires=[0])])
 
         state = np.array(expected_pure_state)
-        expected_output = np.kron(state, state.conj()).reshape([2,2])
+        expected_output = np.kron(state, state.conj()).reshape([2, 2])
 
-        assert np.allclose(
-            simulator_device_1_wire.state, expected_output, **tol
-        )
+        assert np.allclose(simulator_device_1_wire.state, expected_output, **tol)
 
     @pytest.mark.parametrize(
         "op,input,expected_pure_state",
@@ -139,11 +137,9 @@ class TestApply:
         simulator_device_2_wires.apply([op(wires=[0, 1])])
 
         state = np.array(expected_pure_state)
-        expected_output = np.kron(state, state.conj()).reshape([4,4])
+        expected_output = np.kron(state, state.conj()).reshape([4, 4])
 
-        assert np.allclose(
-            simulator_device_2_wires.state, expected_output, **tol
-        )
+        assert np.allclose(simulator_device_2_wires.state, expected_output, **tol)
 
     @pytest.mark.parametrize(
         "op,expected_pure_state,par",
@@ -176,11 +172,9 @@ class TestApply:
         simulator_device_2_wires.apply([op(np.array(par), wires=[0, 1])])
 
         state = np.array(expected_pure_state)
-        expected_output = np.kron(state, state.conj()).reshape([4,4])
+        expected_output = np.kron(state, state.conj()).reshape([4, 4])
 
-        assert np.allclose(
-            simulator_device_2_wires.state, expected_output, **tol
-        )
+        assert np.allclose(simulator_device_2_wires.state, expected_output, **tol)
 
     @pytest.mark.parametrize(
         "op,input,expected_pure_state,par",
@@ -212,18 +206,8 @@ class TestApply:
                 [1 / 2 - 1j / 2, 1 / 2 + 1j / 2],
                 [math.pi / 2],
             ),
-            (
-                qml.Rot,
-                [1, 0],
-                [1 / math.sqrt(2) - 1j / math.sqrt(2), 0],
-                [math.pi / 2, 0, 0],
-            ),
-            (
-                qml.Rot,
-                [1, 0],
-                [1 / math.sqrt(2), 1 / math.sqrt(2)],
-                [0, math.pi / 2, 0],
-            ),
+            (qml.Rot, [1, 0], [1 / math.sqrt(2) - 1j / math.sqrt(2), 0], [math.pi / 2, 0, 0],),
+            (qml.Rot, [1, 0], [1 / math.sqrt(2), 1 / math.sqrt(2)], [0, math.pi / 2, 0],),
             (
                 qml.Rot,
                 [1 / math.sqrt(2), 1 / math.sqrt(2)],
@@ -294,11 +278,9 @@ class TestApply:
         simulator_device_1_wire.apply([op(*par, wires=[0])])
 
         state = np.array(expected_pure_state)
-        expected_output = np.kron(state, state.conj()).reshape([2,2])
+        expected_output = np.kron(state, state.conj()).reshape([2, 2])
 
-        assert np.allclose(
-            simulator_device_1_wire.state, expected_output, **tol
-        )
+        assert np.allclose(simulator_device_1_wire.state, expected_output, **tol)
 
     @pytest.mark.parametrize(
         "op,input,expected_pure_state,par",
@@ -311,12 +293,7 @@ class TestApply:
                 [0, 1 / math.sqrt(2), 1 / 2, -1j / 2],
                 [math.pi / 2],
             ),
-            (
-                qml.CRY,
-                [0, 0, 0, 1],
-                [0, 0, -1 / math.sqrt(2), 1 / math.sqrt(2)],
-                [math.pi / 2],
-            ),
+            (qml.CRY, [0, 0, 0, 1], [0, 0, -1 / math.sqrt(2), 1 / math.sqrt(2)], [math.pi / 2],),
             (qml.CRY, [0, 0, 0, 1], [0, 0, -1, 0], [math.pi]),
             (
                 qml.CRY,
@@ -425,11 +402,9 @@ class TestApply:
         simulator_device_2_wires.apply([op(*par, wires=[0, 1])])
 
         state = np.array(expected_pure_state)
-        expected_output = np.kron(state, state.conj()).reshape([4,4])
+        expected_output = np.kron(state, state.conj()).reshape([4, 4])
 
-        assert np.allclose(
-            simulator_device_2_wires.state, expected_output, **tol
-        )
+        assert np.allclose(simulator_device_2_wires.state, expected_output, **tol)
 
     @pytest.mark.parametrize(
         "operation,par,match",
@@ -478,9 +453,7 @@ class TestApply:
             ),
         ],
     )
-    def test_state_preparation_error(
-        self, simulator_device_1_wire, operation, par, match
-    ):
+    def test_state_preparation_error(self, simulator_device_1_wire, operation, par, match):
         """Tests that the state preparation routines raise proper errors for wrong parameter values."""
 
         simulator_device_1_wire.reset()
@@ -498,9 +471,7 @@ class TestApply:
             qml.DeviceError,
             match="The operation BasisState is only supported at the beginning of a circuit.",
         ):
-            simulator_device_1_wire.apply(
-                [qml.PauliX(0), qml.BasisState(np.array([0]), wires=[0])]
-            )
+            simulator_device_1_wire.apply([qml.PauliX(0), qml.BasisState(np.array([0]), wires=[0])])
 
     def test_qubit_state_vector_not_at_beginning_error(self, simulator_device_1_wire):
         """Tests that application of QubitStateVector raises an error if is not
@@ -528,8 +499,7 @@ class TestStatePreparationErrorsNonAnalytic:
         simulator_device_1_wire.reset()
 
         with pytest.raises(
-            qml.DeviceError,
-            match="The operation BasisState is only supported in analytic mode.",
+            qml.DeviceError, match="The operation BasisState is only supported in analytic mode.",
         ):
             simulator_device_1_wire.apply([qml.BasisState(np.array([0]), wires=[0])])
 
@@ -543,9 +513,8 @@ class TestStatePreparationErrorsNonAnalytic:
             qml.DeviceError,
             match="The operation QubitStateVector is only supported in analytic mode.",
         ):
-            simulator_device_1_wire.apply(
-                [qml.QubitStateVector(np.array([0, 1]), wires=[0])]
-            )
+            simulator_device_1_wire.apply([qml.QubitStateVector(np.array([0, 1]), wires=[0])])
+
 
 @pytest.mark.parametrize("shots,analytic", [(100, True)])
 class TestAnalyticProbability:
@@ -558,6 +527,7 @@ class TestAnalyticProbability:
         simulator_device_1_wire.reset()
         assert simulator_device_1_wire._state is None
         assert simulator_device_1_wire.analytic_probability() is None
+
 
 @pytest.mark.parametrize("shots,analytic", [(100, True)])
 class TestExpval:
@@ -641,51 +611,25 @@ class TestExpval:
                 qml.Hermitian,
                 [1 / math.sqrt(3), 0, 1 / math.sqrt(3), 1 / math.sqrt(3)],
                 5 / 3,
-                [
-                    np.array(
-                        [[1, 1j, 0, 1], [-1j, 1, 0, 0], [0, 0, 1, -1j], [1, 0, 1j, 1]]
-                    )
-                ],
+                [np.array([[1, 1j, 0, 1], [-1j, 1, 0, 0], [0, 0, 1, -1j], [1, 0, 1j, 1]])],
             ),
             (
                 qml.Hermitian,
                 [0, 0, 0, 1],
                 0,
-                [
-                    np.array(
-                        [[0, 1j, 0, 0], [-1j, 0, 0, 0], [0, 0, 0, -1j], [0, 0, 1j, 0]]
-                    )
-                ],
+                [np.array([[0, 1j, 0, 0], [-1j, 0, 0, 0], [0, 0, 0, -1j], [0, 0, 1j, 0]])],
             ),
             (
                 qml.Hermitian,
                 [1 / math.sqrt(2), 0, -1 / math.sqrt(2), 0],
                 1,
-                [
-                    np.array(
-                        [[1, 1j, 0, 0], [-1j, 1, 0, 0], [0, 0, 1, -1j], [0, 0, 1j, 1]]
-                    )
-                ],
+                [np.array([[1, 1j, 0, 0], [-1j, 1, 0, 0], [0, 0, 1, -1j], [0, 0, 1j, 1]])],
             ),
             (
                 qml.Hermitian,
-                [
-                    1 / math.sqrt(3),
-                    -1 / math.sqrt(3),
-                    1 / math.sqrt(6),
-                    1 / math.sqrt(6),
-                ],
+                [1 / math.sqrt(3), -1 / math.sqrt(3), 1 / math.sqrt(6), 1 / math.sqrt(6),],
                 1,
-                [
-                    np.array(
-                        [
-                            [1, 1j, 0, 0.5j],
-                            [-1j, 1, 0, 0],
-                            [0, 0, 1, -1j],
-                            [-0.5j, 0, 1j, 1],
-                        ]
-                    )
-                ],
+                [np.array([[1, 1j, 0, 0.5j], [-1j, 1, 0, 0], [0, 0, 1, -1j], [-0.5j, 0, 1j, 1],])],
             ),
             (
                 qml.Hermitian,
@@ -765,12 +709,7 @@ class TestVar:
             (qml.Identity, [1 / math.sqrt(2), -1 / math.sqrt(2)], 0, []),
             (qml.Hermitian, [1, 0], 1, [[[1, 1j], [-1j, 1]]]),
             (qml.Hermitian, [0, 1], 1, [[[1, 1j], [-1j, 1]]]),
-            (
-                qml.Hermitian,
-                [1 / math.sqrt(2), -1 / math.sqrt(2)],
-                1,
-                [[[1, 1j], [-1j, 1]]],
-            ),
+            (qml.Hermitian, [1 / math.sqrt(2), -1 / math.sqrt(2)], 1, [[[1, 1j], [-1j, 1]]],),
         ],
     )
     def test_var_single_wire_with_parameters(
@@ -877,9 +816,7 @@ class TestSample:
         the correct dimensions
         """
         simulator_device_2_wires.reset()
-        simulator_device_2_wires.apply(
-            [qml.RX(1.5708, wires=[0]), qml.RX(1.5708, wires=[1])]
-        )
+        simulator_device_2_wires.apply([qml.RX(1.5708, wires=[0]), qml.RX(1.5708, wires=[1])])
 
         simulator_device_2_wires.shots = 10
         simulator_device_2_wires._samples = simulator_device_2_wires.generate_samples()
@@ -893,9 +830,7 @@ class TestSample:
 
         simulator_device_2_wires.shots = 17
         simulator_device_2_wires._samples = simulator_device_2_wires.generate_samples()
-        s3 = simulator_device_2_wires.sample(
-            qml.Hermitian(np.diag([1, 1, 1, -1]), wires=[0, 1])
-        )
+        s3 = simulator_device_2_wires.sample(qml.Hermitian(np.diag([1, 1, 1, -1]), wires=[0, 1]))
         assert np.array_equal(s3.shape, (17,))
 
     def test_sample_values(self, simulator_device_2_wires, tol):
@@ -919,34 +854,50 @@ class TestState:
     """Test the state property."""
 
     @pytest.mark.parametrize("shots,analytic", [(100, True)])
-    @pytest.mark.parametrize("ops,expected_pure_state", [
-        ([qml.PauliX(0), qml.PauliX(1)], [0, 0, 0, 1]),
-        ([qml.PauliX(0), qml.PauliY(1)], [0, 0, 0, 1j]),
-        ([qml.PauliZ(0), qml.PauliZ(1)], [1, 0, 0, 0]),
-    ])
+    @pytest.mark.parametrize(
+        "ops,expected_pure_state",
+        [
+            ([qml.PauliX(0), qml.PauliX(1)], [0, 0, 0, 1]),
+            ([qml.PauliX(0), qml.PauliY(1)], [0, 0, 0, 1j]),
+            ([qml.PauliZ(0), qml.PauliZ(1)], [1, 0, 0, 0]),
+        ],
+    )
     def test_state_pauli_operations(self, simulator_device_2_wires, ops, expected_pure_state, tol):
         """Test that the state reflects Pauli operations correctly."""
         simulator_device_2_wires.reset()
         simulator_device_2_wires.apply(ops)
 
         state = np.array(expected_pure_state)
-        expected_output = np.kron(state, state.conj()).reshape([4,4])
+        expected_output = np.kron(state, state.conj()).reshape([4, 4])
 
         assert np.allclose(simulator_device_2_wires.state, expected_output, **tol)
 
     @pytest.mark.parametrize("shots,analytic", [(100, True)])
-    @pytest.mark.parametrize("ops,diag_ops,expected_pure_state", [
-        ([qml.PauliX(0), qml.PauliX(1)], [], [0, 0, 0, 1]),
-        ([qml.PauliX(0), qml.PauliY(1)], [qml.Hadamard(0)], [0, 1j/np.sqrt(2), 0, -1j/np.sqrt(2)]),
-        ([qml.PauliZ(0), qml.PauliZ(1)], [qml.Hadamard(1)], [1/np.sqrt(2), 1/np.sqrt(2), 0, 0]),
-    ])
-    def test_state_pauli_operations_and_observables(self, simulator_device_2_wires, ops, diag_ops, expected_pure_state, tol):
+    @pytest.mark.parametrize(
+        "ops,diag_ops,expected_pure_state",
+        [
+            ([qml.PauliX(0), qml.PauliX(1)], [], [0, 0, 0, 1]),
+            (
+                [qml.PauliX(0), qml.PauliY(1)],
+                [qml.Hadamard(0)],
+                [0, 1j / np.sqrt(2), 0, -1j / np.sqrt(2)],
+            ),
+            (
+                [qml.PauliZ(0), qml.PauliZ(1)],
+                [qml.Hadamard(1)],
+                [1 / np.sqrt(2), 1 / np.sqrt(2), 0, 0],
+            ),
+        ],
+    )
+    def test_state_pauli_operations_and_observables(
+        self, simulator_device_2_wires, ops, diag_ops, expected_pure_state, tol
+    ):
         """Test that the state reflects Pauli operations and observable rotations correctly."""
         simulator_device_2_wires.reset()
         simulator_device_2_wires.apply(ops, rotations=diag_ops)
 
         state = np.array(expected_pure_state)
-        expected_output = np.kron(state, state.conj()).reshape([4,4])
+        expected_output = np.kron(state, state.conj()).reshape([4, 4])
 
         assert np.allclose(simulator_device_2_wires.state, expected_output, **tol)
 

--- a/tests/test_mixed_simulator_device.py
+++ b/tests/test_mixed_simulator_device.py
@@ -1,0 +1,959 @@
+# Copyright 2018 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Unit tests for the MixedStateMixedStateSimulatorDevice
+"""
+import pytest
+import math
+
+import pennylane as qml
+import numpy as np
+from pennylane_cirq import MixedStateSimulatorDevice
+import cirq
+
+
+class TestDeviceIntegration:
+    """Tests that the MixedStateSimulatorDevice integrates well with PennyLane"""
+
+    def test_device_loading(self):
+        """Tests that the cirq.simulator device is properly loaded"""
+
+        dev = qml.device("cirq.mixedsimulator", wires=2)
+
+        assert dev.num_wires == 2
+        assert dev.shots == 1000
+        assert dev.short_name == "cirq.mixedsimulator"
+
+        assert isinstance(dev, MixedStateSimulatorDevice)
+
+
+@pytest.fixture(scope="function")
+def simulator_device_1_wire(shots, analytic):
+    """Return a single wire instance of the MixedStateSimulatorDevice class."""
+    yield MixedStateSimulatorDevice(1, shots=shots, analytic=analytic)
+
+
+@pytest.fixture(scope="function")
+def simulator_device_2_wires(shots, analytic):
+    """Return a two wire instance of the MixedStateSimulatorDevice class."""
+    yield MixedStateSimulatorDevice(2, shots=shots, analytic=analytic)
+
+
+@pytest.fixture(scope="function")
+def simulator_device_3_wires(shots, analytic):
+    """Return a three wire instance of the MixedStateSimulatorDevice class."""
+    yield MixedStateSimulatorDevice(3, shots=shots, analytic=analytic)
+
+
+@pytest.mark.parametrize("shots,analytic", [(100, True)])
+class TestApply:
+    """Tests that gates are correctly applied"""
+
+    @pytest.mark.parametrize(
+        "op,input,expected_pure_state",
+        [
+            (qml.PauliX, [1, 0], np.array([0, 1])),
+            (
+                qml.PauliX,
+                [1 / math.sqrt(2), 1 / math.sqrt(2)],
+                [1 / math.sqrt(2), 1 / math.sqrt(2)],
+            ),
+            (qml.PauliY, [1, 0], [0, 1j]),
+            (
+                qml.PauliY,
+                [1 / math.sqrt(2), 1 / math.sqrt(2)],
+                [-1j / math.sqrt(2), 1j / math.sqrt(2)],
+            ),
+            (qml.PauliZ, [1, 0], [1, 0]),
+            (
+                qml.PauliZ,
+                [1 / math.sqrt(2), 1 / math.sqrt(2)],
+                [1 / math.sqrt(2), -1 / math.sqrt(2)],
+            ),
+            (qml.Hadamard, [1, 0], [1 / math.sqrt(2), 1 / math.sqrt(2)]),
+            (qml.Hadamard, [1 / math.sqrt(2), -1 / math.sqrt(2)], [0, 1]),
+        ],
+    )
+    def test_apply_operation_single_wire_no_parameters(
+        self, simulator_device_1_wire, tol, op, input, expected_pure_state
+    ):
+        """Tests that applying an operation yields the expected output state for single wire
+           operations that have no parameters."""
+
+        simulator_device_1_wire.reset()
+        simulator_device_1_wire._initial_state = np.array(input, dtype=np.complex64)
+        simulator_device_1_wire.apply([op(wires=[0])])
+
+        state = np.array(expected_pure_state)
+        expected_output = np.kron(state, state.conj()).reshape([2,2])
+
+        assert np.allclose(
+            simulator_device_1_wire.state, expected_output, **tol
+        )
+
+    @pytest.mark.parametrize(
+        "op,input,expected_pure_state",
+        [
+            (qml.CNOT, [1, 0, 0, 0], [1, 0, 0, 0]),
+            (qml.CNOT, [0, 0, 1, 0], [0, 0, 0, 1]),
+            (
+                qml.CNOT,
+                [1 / math.sqrt(2), 0, 0, 1 / math.sqrt(2)],
+                [1 / math.sqrt(2), 0, 1 / math.sqrt(2), 0],
+            ),
+            (qml.SWAP, [1, 0, 0, 0], [1, 0, 0, 0]),
+            (qml.SWAP, [0, 0, 1, 0], [0, 1, 0, 0]),
+            (
+                qml.SWAP,
+                [1 / math.sqrt(2), 0, -1 / math.sqrt(2), 0],
+                [1 / math.sqrt(2), -1 / math.sqrt(2), 0, 0],
+            ),
+            (qml.CZ, [1, 0, 0, 0], [1, 0, 0, 0]),
+            (qml.CZ, [0, 0, 0, 1], [0, 0, 0, -1]),
+            (
+                qml.CZ,
+                [1 / math.sqrt(2), 0, 0, -1 / math.sqrt(2)],
+                [1 / math.sqrt(2), 0, 0, 1 / math.sqrt(2)],
+            ),
+        ],
+    )
+    def test_apply_operation_two_wires_no_parameters(
+        self, simulator_device_2_wires, tol, op, input, expected_pure_state
+    ):
+        """Tests that applying an operation yields the expected output state for two wire
+           operations that have no parameters."""
+
+        simulator_device_2_wires.reset()
+        simulator_device_2_wires._initial_state = np.array(input, dtype=np.complex64)
+        simulator_device_2_wires.apply([op(wires=[0, 1])])
+
+        state = np.array(expected_pure_state)
+        expected_output = np.kron(state, state.conj()).reshape([4,4])
+
+        assert np.allclose(
+            simulator_device_2_wires.state, expected_output, **tol
+        )
+
+    @pytest.mark.parametrize(
+        "op,expected_pure_state,par",
+        [
+            (qml.BasisState, [0, 0, 1, 0], [1, 0]),
+            (qml.BasisState, [0, 0, 1, 0], [1, 0]),
+            (qml.BasisState, [0, 0, 0, 1], [1, 1]),
+            (qml.QubitStateVector, [0, 0, 1, 0], [0, 0, 1, 0]),
+            (qml.QubitStateVector, [0, 0, 1, 0], [0, 0, 1, 0]),
+            (qml.QubitStateVector, [0, 0, 0, 1], [0, 0, 0, 1]),
+            (
+                qml.QubitStateVector,
+                [1 / math.sqrt(3), 0, 1 / math.sqrt(3), 1 / math.sqrt(3)],
+                [1 / math.sqrt(3), 0, 1 / math.sqrt(3), 1 / math.sqrt(3)],
+            ),
+            (
+                qml.QubitStateVector,
+                [1 / math.sqrt(3), 0, -1 / math.sqrt(3), 1 / math.sqrt(3)],
+                [1 / math.sqrt(3), 0, -1 / math.sqrt(3), 1 / math.sqrt(3)],
+            ),
+        ],
+    )
+    def test_apply_operation_state_preparation(
+        self, simulator_device_2_wires, tol, op, expected_pure_state, par
+    ):
+        """Tests that applying an operation yields the expected output state for single wire
+           operations that have no parameters."""
+
+        simulator_device_2_wires.reset()
+        simulator_device_2_wires.apply([op(np.array(par), wires=[0, 1])])
+
+        state = np.array(expected_pure_state)
+        expected_output = np.kron(state, state.conj()).reshape([4,4])
+
+        assert np.allclose(
+            simulator_device_2_wires.state, expected_output, **tol
+        )
+
+    @pytest.mark.parametrize(
+        "op,input,expected_pure_state,par",
+        [
+            (qml.PhaseShift, [1, 0], [1, 0], [math.pi / 2]),
+            (qml.PhaseShift, [0, 1], [0, 1j], [math.pi / 2]),
+            (
+                qml.PhaseShift,
+                [1 / math.sqrt(2), 1 / math.sqrt(2)],
+                [1 / math.sqrt(2), 1 / 2 + 1j / 2],
+                [math.pi / 4],
+            ),
+            (qml.RX, [1, 0], [1 / math.sqrt(2), -1j * 1 / math.sqrt(2)], [math.pi / 2]),
+            (qml.RX, [1, 0], [0, -1j], [math.pi]),
+            (
+                qml.RX,
+                [1 / math.sqrt(2), 1 / math.sqrt(2)],
+                [1 / 2 - 1j / 2, 1 / 2 - 1j / 2],
+                [math.pi / 2],
+            ),
+            (qml.RY, [1, 0], [1 / math.sqrt(2), 1 / math.sqrt(2)], [math.pi / 2]),
+            (qml.RY, [1, 0], [0, 1], [math.pi]),
+            (qml.RY, [1 / math.sqrt(2), 1 / math.sqrt(2)], [0, 1], [math.pi / 2]),
+            (qml.RZ, [1, 0], [1 / math.sqrt(2) - 1j / math.sqrt(2), 0], [math.pi / 2]),
+            (qml.RZ, [0, 1], [0, 1j], [math.pi]),
+            (
+                qml.RZ,
+                [1 / math.sqrt(2), 1 / math.sqrt(2)],
+                [1 / 2 - 1j / 2, 1 / 2 + 1j / 2],
+                [math.pi / 2],
+            ),
+            (
+                qml.Rot,
+                [1, 0],
+                [1 / math.sqrt(2) - 1j / math.sqrt(2), 0],
+                [math.pi / 2, 0, 0],
+            ),
+            (
+                qml.Rot,
+                [1, 0],
+                [1 / math.sqrt(2), 1 / math.sqrt(2)],
+                [0, math.pi / 2, 0],
+            ),
+            (
+                qml.Rot,
+                [1 / math.sqrt(2), 1 / math.sqrt(2)],
+                [1 / 2 - 1j / 2, 1 / 2 + 1j / 2],
+                [0, 0, math.pi / 2],
+            ),
+            (
+                qml.Rot,
+                [1, 0],
+                [-1j / math.sqrt(2), -1 / math.sqrt(2)],
+                [math.pi / 2, -math.pi / 2, math.pi / 2],
+            ),
+            (
+                qml.Rot,
+                [1 / math.sqrt(2), 1 / math.sqrt(2)],
+                [1 / 2 + 1j / 2, -1 / 2 + 1j / 2],
+                [-math.pi / 2, math.pi, math.pi],
+            ),
+            (
+                qml.QubitUnitary,
+                [1, 0],
+                [1j / math.sqrt(2), 1j / math.sqrt(2)],
+                [
+                    np.array(
+                        [
+                            [1j / math.sqrt(2), 1j / math.sqrt(2)],
+                            [1j / math.sqrt(2), -1j / math.sqrt(2)],
+                        ]
+                    )
+                ],
+            ),
+            (
+                qml.QubitUnitary,
+                [0, 1],
+                [1j / math.sqrt(2), -1j / math.sqrt(2)],
+                [
+                    np.array(
+                        [
+                            [1j / math.sqrt(2), 1j / math.sqrt(2)],
+                            [1j / math.sqrt(2), -1j / math.sqrt(2)],
+                        ]
+                    )
+                ],
+            ),
+            (
+                qml.QubitUnitary,
+                [1 / math.sqrt(2), -1 / math.sqrt(2)],
+                [0, 1j],
+                [
+                    np.array(
+                        [
+                            [1j / math.sqrt(2), 1j / math.sqrt(2)],
+                            [1j / math.sqrt(2), -1j / math.sqrt(2)],
+                        ]
+                    )
+                ],
+            ),
+        ],
+    )
+    def test_apply_operation_single_wire_with_parameters(
+        self, simulator_device_1_wire, tol, op, input, expected_pure_state, par
+    ):
+        """Tests that applying an operation yields the expected output state for single wire
+           operations that have no parameters."""
+
+        simulator_device_1_wire.reset()
+        simulator_device_1_wire._initial_state = np.array(input, dtype=np.complex64)
+        simulator_device_1_wire.apply([op(*par, wires=[0])])
+
+        state = np.array(expected_pure_state)
+        expected_output = np.kron(state, state.conj()).reshape([2,2])
+
+        assert np.allclose(
+            simulator_device_1_wire.state, expected_output, **tol
+        )
+
+    @pytest.mark.parametrize(
+        "op,input,expected_pure_state,par",
+        [
+            (qml.CRX, [0, 1, 0, 0], [0, 1, 0, 0], [math.pi / 2]),
+            (qml.CRX, [0, 0, 0, 1], [0, 0, -1j, 0], [math.pi]),
+            (
+                qml.CRX,
+                [0, 1 / math.sqrt(2), 1 / math.sqrt(2), 0],
+                [0, 1 / math.sqrt(2), 1 / 2, -1j / 2],
+                [math.pi / 2],
+            ),
+            (
+                qml.CRY,
+                [0, 0, 0, 1],
+                [0, 0, -1 / math.sqrt(2), 1 / math.sqrt(2)],
+                [math.pi / 2],
+            ),
+            (qml.CRY, [0, 0, 0, 1], [0, 0, -1, 0], [math.pi]),
+            (
+                qml.CRY,
+                [1 / math.sqrt(2), 1 / math.sqrt(2), 0, 0],
+                [1 / math.sqrt(2), 1 / math.sqrt(2), 0, 0],
+                [math.pi / 2],
+            ),
+            (
+                qml.CRZ,
+                [0, 0, 0, 1],
+                [0, 0, 0, 1 / math.sqrt(2) + 1j / math.sqrt(2)],
+                [math.pi / 2],
+            ),
+            (qml.CRZ, [0, 0, 0, 1], [0, 0, 0, 1j], [math.pi]),
+            (
+                qml.CRZ,
+                [1 / math.sqrt(2), 1 / math.sqrt(2), 0, 0],
+                [1 / math.sqrt(2), 1 / math.sqrt(2), 0, 0],
+                [math.pi / 2],
+            ),
+            (
+                qml.CRot,
+                [0, 0, 0, 1],
+                [0, 0, 0, 1 / math.sqrt(2) + 1j / math.sqrt(2)],
+                [math.pi / 2, 0, 0],
+            ),
+            (
+                qml.CRot,
+                [0, 0, 0, 1],
+                [0, 0, -1 / math.sqrt(2), 1 / math.sqrt(2)],
+                [0, math.pi / 2, 0],
+            ),
+            (
+                qml.CRot,
+                [0, 0, 1 / math.sqrt(2), 1 / math.sqrt(2)],
+                [0, 0, 1 / 2 - 1j / 2, 1 / 2 + 1j / 2],
+                [0, 0, math.pi / 2],
+            ),
+            (
+                qml.CRot,
+                [0, 0, 0, 1],
+                [0, 0, 1 / math.sqrt(2), 1j / math.sqrt(2)],
+                [math.pi / 2, -math.pi / 2, math.pi / 2],
+            ),
+            (
+                qml.CRot,
+                [0, 1 / math.sqrt(2), 1 / math.sqrt(2), 0],
+                [0, 1 / math.sqrt(2), 0, -1 / 2 + 1j / 2],
+                [-math.pi / 2, math.pi, math.pi],
+            ),
+            (
+                qml.QubitUnitary,
+                [1, 0, 0, 0],
+                [1, 0, 0, 0],
+                [
+                    np.array(
+                        [
+                            [1, 0, 0, 0],
+                            [0, 1 / math.sqrt(2), 1 / math.sqrt(2), 0],
+                            [0, 1 / math.sqrt(2), -1 / math.sqrt(2), 0],
+                            [0, 0, 0, 1],
+                        ]
+                    )
+                ],
+            ),
+            (
+                qml.QubitUnitary,
+                [0, 1, 0, 0],
+                [0, 1 / math.sqrt(2), 1 / math.sqrt(2), 0],
+                [
+                    np.array(
+                        [
+                            [1, 0, 0, 0],
+                            [0, 1 / math.sqrt(2), 1 / math.sqrt(2), 0],
+                            [0, 1 / math.sqrt(2), -1 / math.sqrt(2), 0],
+                            [0, 0, 0, 1],
+                        ]
+                    )
+                ],
+            ),
+            (
+                qml.QubitUnitary,
+                [1 / 2, 1 / 2, -1 / 2, 1 / 2],
+                [1 / 2, 0, 1 / math.sqrt(2), 1 / 2],
+                [
+                    np.array(
+                        [
+                            [1, 0, 0, 0],
+                            [0, 1 / math.sqrt(2), 1 / math.sqrt(2), 0],
+                            [0, 1 / math.sqrt(2), -1 / math.sqrt(2), 0],
+                            [0, 0, 0, 1],
+                        ]
+                    )
+                ],
+            ),
+        ],
+    )
+    def test_apply_operation_two_wires_with_parameters(
+        self, simulator_device_2_wires, tol, op, input, expected_pure_state, par
+    ):
+        """Tests that applying an operation yields the expected output state for single wire
+           operations that have no parameters."""
+
+        simulator_device_2_wires.reset()
+        simulator_device_2_wires._initial_state = np.array(input, dtype=np.complex64)
+        simulator_device_2_wires.apply([op(*par, wires=[0, 1])])
+
+        state = np.array(expected_pure_state)
+        expected_output = np.kron(state, state.conj()).reshape([4,4])
+
+        assert np.allclose(
+            simulator_device_2_wires.state, expected_output, **tol
+        )
+
+    @pytest.mark.parametrize(
+        "operation,par,match",
+        [
+            (qml.BasisState, [2], "Argument for BasisState can only contain 0 and 1"),
+            (qml.BasisState, [1.2], "Argument for BasisState can only contain 0 and 1"),
+            (
+                qml.BasisState,
+                [0, 0, 1],
+                "For BasisState, the state has to be specified for the correct number of qubits",
+            ),
+            (
+                qml.BasisState,
+                [0, 0],
+                "For BasisState, the state has to be specified for the correct number of qubits",
+            ),
+            (
+                qml.QubitStateVector,
+                [0, 0, 1],
+                "For QubitStateVector, the state has to be specified for the correct number of qubits",
+            ),
+            (
+                qml.QubitStateVector,
+                [0, 0, 1, 0],
+                "For QubitStateVector, the state has to be specified for the correct number of qubits",
+            ),
+            (
+                qml.QubitStateVector,
+                [1],
+                "For QubitStateVector, the state has to be specified for the correct number of qubits",
+            ),
+            (
+                qml.QubitStateVector,
+                [0.5, 0.5],
+                "The given state for QubitStateVector is not properly normalized to 1",
+            ),
+            (
+                qml.QubitStateVector,
+                [1.1, 0],
+                "The given state for QubitStateVector is not properly normalized to 1",
+            ),
+            (
+                qml.QubitStateVector,
+                [0.7, 0.7j],
+                "The given state for QubitStateVector is not properly normalized to 1",
+            ),
+        ],
+    )
+    def test_state_preparation_error(
+        self, simulator_device_1_wire, operation, par, match
+    ):
+        """Tests that the state preparation routines raise proper errors for wrong parameter values."""
+
+        simulator_device_1_wire.reset()
+
+        with pytest.raises(qml.DeviceError, match=match):
+            simulator_device_1_wire.apply([operation(np.array(par), wires=[0])])
+
+    def test_basis_state_not_at_beginning_error(self, simulator_device_1_wire):
+        """Tests that application of BasisState raises an error if is not
+        the first operation."""
+
+        simulator_device_1_wire.reset()
+
+        with pytest.raises(
+            qml.DeviceError,
+            match="The operation BasisState is only supported at the beginning of a circuit.",
+        ):
+            simulator_device_1_wire.apply(
+                [qml.PauliX(0), qml.BasisState(np.array([0]), wires=[0])]
+            )
+
+    def test_qubit_state_vector_not_at_beginning_error(self, simulator_device_1_wire):
+        """Tests that application of QubitStateVector raises an error if is not
+        the first operation."""
+
+        simulator_device_1_wire.reset()
+
+        with pytest.raises(
+            qml.DeviceError,
+            match="The operation QubitStateVector is only supported at the beginning of a circuit.",
+        ):
+            simulator_device_1_wire.apply(
+                [qml.PauliX(0), qml.QubitStateVector(np.array([0, 1]), wires=[0])]
+            )
+
+
+@pytest.mark.parametrize("shots,analytic", [(100, False)])
+class TestStatePreparationErrorsNonAnalytic:
+    """Tests state preparation errors that occur for non-analytic devices."""
+
+    def test_basis_state_not_analytic_error(self, simulator_device_1_wire):
+        """Tests that application of BasisState raises an error if the device
+        is not in analytic mode."""
+
+        simulator_device_1_wire.reset()
+
+        with pytest.raises(
+            qml.DeviceError,
+            match="The operation BasisState is only supported in analytic mode.",
+        ):
+            simulator_device_1_wire.apply([qml.BasisState(np.array([0]), wires=[0])])
+
+    def test_qubit_state_vector_not_analytic_error(self, simulator_device_1_wire):
+        """Tests that application of QubitStateVector raises an error if the device
+        is not in analytic mode."""
+
+        simulator_device_1_wire.reset()
+
+        with pytest.raises(
+            qml.DeviceError,
+            match="The operation QubitStateVector is only supported in analytic mode.",
+        ):
+            simulator_device_1_wire.apply(
+                [qml.QubitStateVector(np.array([0, 1]), wires=[0])]
+            )
+
+@pytest.mark.parametrize("shots,analytic", [(100, True)])
+class TestAnalyticProbability:
+    """Tests the analytic_probability method works as expected."""
+
+    def test_analytic_probability_is_none(self, simulator_device_1_wire):
+        """Tests that analytic_probability returns None if the state of the
+        device is None."""
+
+        simulator_device_1_wire.reset()
+        assert simulator_device_1_wire._state is None
+        assert simulator_device_1_wire.analytic_probability() is None
+
+@pytest.mark.parametrize("shots,analytic", [(100, True)])
+class TestExpval:
+    """Tests that expectation values are properly calculated or that the proper errors are raised."""
+
+    @pytest.mark.parametrize(
+        "operation,input,expected_output",
+        [
+            (qml.Identity, [1, 0], 1),
+            (qml.Identity, [0, 1], 1),
+            (qml.Identity, [1 / math.sqrt(2), -1 / math.sqrt(2)], 1),
+            (qml.PauliX, [1 / math.sqrt(2), 1 / math.sqrt(2)], 1),
+            (qml.PauliX, [1 / math.sqrt(2), -1 / math.sqrt(2)], -1),
+            (qml.PauliX, [1, 0], 0),
+            (qml.PauliY, [1 / math.sqrt(2), 1j / math.sqrt(2)], 1),
+            (qml.PauliY, [1 / math.sqrt(2), -1j / math.sqrt(2)], -1),
+            (qml.PauliY, [1, 0], 0),
+            (qml.PauliZ, [1, 0], 1),
+            (qml.PauliZ, [0, 1], -1),
+            (qml.PauliZ, [1 / math.sqrt(2), 1 / math.sqrt(2)], 0),
+            (qml.Hadamard, [1, 0], 1 / math.sqrt(2)),
+            (qml.Hadamard, [0, 1], -1 / math.sqrt(2)),
+            (qml.Hadamard, [1 / math.sqrt(2), 1 / math.sqrt(2)], 1 / math.sqrt(2)),
+        ],
+    )
+    def test_expval_single_wire_no_parameters(
+        self, simulator_device_1_wire, tol, operation, input, expected_output
+    ):
+        """Tests that expectation values are properly calculated for single-wire observables without parameters."""
+
+        op = operation(0, do_queue=False)
+
+        simulator_device_1_wire.reset()
+        simulator_device_1_wire.apply(
+            [qml.QubitStateVector(np.array(input), wires=[0])], rotations=op.diagonalizing_gates()
+        )
+
+        res = simulator_device_1_wire.expval(op)
+
+        assert np.isclose(res, expected_output, **tol)
+
+    @pytest.mark.parametrize(
+        "operation,input,expected_output,par",
+        [
+            (qml.Hermitian, [1, 0], 1, [np.array([[1, 1j], [-1j, 1]])]),
+            (qml.Hermitian, [0, 1], 1, [np.array([[1, 1j], [-1j, 1]])]),
+            (
+                qml.Hermitian,
+                [1 / math.sqrt(2), -1 / math.sqrt(2)],
+                1,
+                [np.array([[1, 1j], [-1j, 1]])],
+            ),
+        ],
+    )
+    def test_expval_single_wire_with_parameters(
+        self, simulator_device_1_wire, tol, operation, input, expected_output, par
+    ):
+        """Tests that expectation values are properly calculated for single-wire observables with parameters."""
+
+        op = operation(par[0], 0, do_queue=False)
+
+        simulator_device_1_wire.reset()
+        simulator_device_1_wire.apply(
+            [qml.QubitStateVector(np.array(input), wires=[0])], rotations=op.diagonalizing_gates()
+        )
+
+        res = simulator_device_1_wire.expval(op)
+
+        assert np.isclose(res, expected_output, **tol)
+
+    @pytest.mark.parametrize(
+        "operation,input,expected_output,par",
+        [
+            (
+                qml.Hermitian,
+                [0, 1, 0, 0],
+                -1,
+                [np.array([[1, 0, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1],])],
+            ),
+            (
+                qml.Hermitian,
+                [1 / math.sqrt(3), 0, 1 / math.sqrt(3), 1 / math.sqrt(3)],
+                5 / 3,
+                [
+                    np.array(
+                        [[1, 1j, 0, 1], [-1j, 1, 0, 0], [0, 0, 1, -1j], [1, 0, 1j, 1]]
+                    )
+                ],
+            ),
+            (
+                qml.Hermitian,
+                [0, 0, 0, 1],
+                0,
+                [
+                    np.array(
+                        [[0, 1j, 0, 0], [-1j, 0, 0, 0], [0, 0, 0, -1j], [0, 0, 1j, 0]]
+                    )
+                ],
+            ),
+            (
+                qml.Hermitian,
+                [1 / math.sqrt(2), 0, -1 / math.sqrt(2), 0],
+                1,
+                [
+                    np.array(
+                        [[1, 1j, 0, 0], [-1j, 1, 0, 0], [0, 0, 1, -1j], [0, 0, 1j, 1]]
+                    )
+                ],
+            ),
+            (
+                qml.Hermitian,
+                [
+                    1 / math.sqrt(3),
+                    -1 / math.sqrt(3),
+                    1 / math.sqrt(6),
+                    1 / math.sqrt(6),
+                ],
+                1,
+                [
+                    np.array(
+                        [
+                            [1, 1j, 0, 0.5j],
+                            [-1j, 1, 0, 0],
+                            [0, 0, 1, -1j],
+                            [-0.5j, 0, 1j, 1],
+                        ]
+                    )
+                ],
+            ),
+            (
+                qml.Hermitian,
+                [1 / math.sqrt(2), 0, 0, 1 / math.sqrt(2)],
+                1,
+                [np.array([[1, 0, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1]])],
+            ),
+            (
+                qml.Hermitian,
+                [0, 1 / math.sqrt(2), -1 / math.sqrt(2), 0],
+                -1,
+                [np.array([[1, 0, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1]])],
+            ),
+        ],
+    )
+    def test_expval_two_wires_with_parameters(
+        self, simulator_device_2_wires, tol, operation, input, expected_output, par
+    ):
+        """Tests that expectation values are properly calculated for two-wire observables with parameters."""
+
+        op = operation(par[0], [0, 1], do_queue=False)
+
+        simulator_device_2_wires.reset()
+        simulator_device_2_wires.apply(
+            [qml.QubitStateVector(np.array(input), wires=[0, 1])],
+            rotations=op.diagonalizing_gates(),
+        )
+
+        res = simulator_device_2_wires.expval(op)
+
+        assert np.isclose(res, expected_output, **tol)
+
+
+@pytest.mark.parametrize("shots,analytic", [(100, True)])
+class TestVar:
+    """Tests that variances are properly calculated."""
+
+    @pytest.mark.parametrize(
+        "operation,input,expected_output",
+        [
+            (qml.PauliX, [1 / math.sqrt(2), 1 / math.sqrt(2)], 0),
+            (qml.PauliX, [1 / math.sqrt(2), -1 / math.sqrt(2)], 0),
+            (qml.PauliX, [1, 0], 1),
+            (qml.PauliY, [1 / math.sqrt(2), 1j / math.sqrt(2)], 0),
+            (qml.PauliY, [1 / math.sqrt(2), -1j / math.sqrt(2)], 0),
+            (qml.PauliY, [1, 0], 1),
+            (qml.PauliZ, [1, 0], 0),
+            (qml.PauliZ, [0, 1], 0),
+            (qml.PauliZ, [1 / math.sqrt(2), 1 / math.sqrt(2)], 1),
+            (qml.Hadamard, [1, 0], 1 / 2),
+            (qml.Hadamard, [0, 1], 1 / 2),
+            (qml.Hadamard, [1 / math.sqrt(2), 1 / math.sqrt(2)], 1 / 2),
+        ],
+    )
+    def test_var_single_wire_no_parameters(
+        self, simulator_device_1_wire, tol, operation, input, expected_output
+    ):
+        """Tests that variances are properly calculated for single-wire observables without parameters."""
+
+        op = operation(0, do_queue=False)
+
+        simulator_device_1_wire.reset()
+        simulator_device_1_wire.apply(
+            [qml.QubitStateVector(np.array(input), wires=[0, 1])],
+            rotations=op.diagonalizing_gates(),
+        )
+
+        res = simulator_device_1_wire.var(op)
+
+        assert np.isclose(res, expected_output, **tol)
+
+    @pytest.mark.parametrize(
+        "operation,input,expected_output,par",
+        [
+            (qml.Identity, [1, 0], 0, []),
+            (qml.Identity, [0, 1], 0, []),
+            (qml.Identity, [1 / math.sqrt(2), -1 / math.sqrt(2)], 0, []),
+            (qml.Hermitian, [1, 0], 1, [[[1, 1j], [-1j, 1]]]),
+            (qml.Hermitian, [0, 1], 1, [[[1, 1j], [-1j, 1]]]),
+            (
+                qml.Hermitian,
+                [1 / math.sqrt(2), -1 / math.sqrt(2)],
+                1,
+                [[[1, 1j], [-1j, 1]]],
+            ),
+        ],
+    )
+    def test_var_single_wire_with_parameters(
+        self, simulator_device_1_wire, tol, operation, input, expected_output, par
+    ):
+        """Tests that expectation values are properly calculated for single-wire observables with parameters."""
+
+        if par:
+            op = operation(np.array(*par), 0, do_queue=False)
+        else:
+            op = operation(0, do_queue=False)
+
+        simulator_device_1_wire.reset()
+        simulator_device_1_wire.apply(
+            [qml.QubitStateVector(np.array(input), wires=[0, 1])],
+            rotations=op.diagonalizing_gates(),
+        )
+
+        if par:
+            res = simulator_device_1_wire.var(op)
+        else:
+            res = simulator_device_1_wire.var(op)
+
+        assert np.isclose(res, expected_output, **tol)
+
+    @pytest.mark.parametrize(
+        "operation,input,expected_output,par",
+        [
+            (
+                qml.Hermitian,
+                [1 / math.sqrt(3), 0, 1 / math.sqrt(3), 1 / math.sqrt(3)],
+                11 / 9,
+                [[[1, 1j, 0, 1], [-1j, 1, 0, 0], [0, 0, 1, -1j], [1, 0, 1j, 1]]],
+            ),
+            (
+                qml.Hermitian,
+                [0, 0, 0, 1],
+                1,
+                [[[0, 1j, 0, 0], [-1j, 0, 0, 0], [0, 0, 0, -1j], [0, 0, 1j, 0]]],
+            ),
+            (
+                qml.Hermitian,
+                [1 / math.sqrt(2), 0, -1 / math.sqrt(2), 0],
+                1,
+                [[[1, 1j, 0, 0], [-1j, 1, 0, 0], [0, 0, 1, -1j], [0, 0, 1j, 1]]],
+            ),
+            (
+                qml.Hermitian,
+                [1 / math.sqrt(2), 0, 0, 1 / math.sqrt(2)],
+                0,
+                [[[1, 0, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1]]],
+            ),
+            (
+                qml.Hermitian,
+                [0, 1 / math.sqrt(2), -1 / math.sqrt(2), 0],
+                0,
+                [[[1, 0, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1]]],
+            ),
+        ],
+    )
+    def test_var_two_wires_with_parameters(
+        self, simulator_device_2_wires, tol, operation, input, expected_output, par
+    ):
+        """Tests that variances are properly calculated for two-wire observables with parameters."""
+
+        op = operation(np.array(*par), [0, 1], do_queue=False)
+
+        simulator_device_2_wires.reset()
+        simulator_device_2_wires.apply(
+            [qml.QubitStateVector(np.array(input), wires=[0, 1])],
+            rotations=op.diagonalizing_gates(),
+        )
+
+        res = simulator_device_2_wires.var(op)
+
+        assert np.isclose(res, expected_output, **tol)
+
+
+class TestVarEstimate:
+    """Test the estimation of variances."""
+
+    def test_var_estimate(self):
+        """Test that the variance is not analytically calculated"""
+
+        dev = qml.device("cirq.simulator", wires=1, shots=3, analytic=False)
+
+        @qml.qnode(dev)
+        def circuit():
+            return qml.var(qml.PauliX(0))
+
+        var = circuit()
+
+        # With 3 samples we are guaranteed to see a difference between
+        # an estimated variance an an analytically calculated one
+        assert var != 1.0
+
+
+@pytest.mark.parametrize("shots,analytic", [(100, True)])
+class TestSample:
+    """Test sampling."""
+
+    def test_sample_dimensions(self, simulator_device_2_wires):
+        """Tests if the samples returned by the sample function have
+        the correct dimensions
+        """
+        simulator_device_2_wires.reset()
+        simulator_device_2_wires.apply(
+            [qml.RX(1.5708, wires=[0]), qml.RX(1.5708, wires=[1])]
+        )
+
+        simulator_device_2_wires.shots = 10
+        simulator_device_2_wires._samples = simulator_device_2_wires.generate_samples()
+        s1 = simulator_device_2_wires.sample(qml.PauliZ(0))
+        assert np.array_equal(s1.shape, (10,))
+
+        simulator_device_2_wires.shots = 12
+        simulator_device_2_wires._samples = simulator_device_2_wires.generate_samples()
+        s2 = simulator_device_2_wires.sample(qml.PauliZ(1))
+        assert np.array_equal(s2.shape, (12,))
+
+        simulator_device_2_wires.shots = 17
+        simulator_device_2_wires._samples = simulator_device_2_wires.generate_samples()
+        s3 = simulator_device_2_wires.sample(
+            qml.Hermitian(np.diag([1, 1, 1, -1]), wires=[0, 1])
+        )
+        assert np.array_equal(s3.shape, (17,))
+
+    def test_sample_values(self, simulator_device_2_wires, tol):
+        """Tests if the samples returned by sample have
+        the correct values
+        """
+
+        simulator_device_2_wires.reset()
+
+        simulator_device_2_wires.apply([qml.RX(1.5708, wires=[0])])
+        simulator_device_2_wires._samples = simulator_device_2_wires.generate_samples()
+
+        s1 = simulator_device_2_wires.sample(qml.PauliZ(0))
+
+        # s1 should only contain 1 and -1, which is guaranteed if
+        # they square to 1
+        assert np.allclose(s1 ** 2, 1, **tol)
+
+
+class TestState:
+    """Test the state property."""
+
+    @pytest.mark.parametrize("shots,analytic", [(100, True)])
+    @pytest.mark.parametrize("ops,expected_pure_state", [
+        ([qml.PauliX(0), qml.PauliX(1)], [0, 0, 0, 1]),
+        ([qml.PauliX(0), qml.PauliY(1)], [0, 0, 0, 1j]),
+        ([qml.PauliZ(0), qml.PauliZ(1)], [1, 0, 0, 0]),
+    ])
+    def test_state_pauli_operations(self, simulator_device_2_wires, ops, expected_pure_state, tol):
+        """Test that the state reflects Pauli operations correctly."""
+        simulator_device_2_wires.reset()
+        simulator_device_2_wires.apply(ops)
+
+        state = np.array(expected_pure_state)
+        expected_output = np.kron(state, state.conj()).reshape([4,4])
+
+        assert np.allclose(simulator_device_2_wires.state, expected_output, **tol)
+
+    @pytest.mark.parametrize("shots,analytic", [(100, True)])
+    @pytest.mark.parametrize("ops,diag_ops,expected_pure_state", [
+        ([qml.PauliX(0), qml.PauliX(1)], [], [0, 0, 0, 1]),
+        ([qml.PauliX(0), qml.PauliY(1)], [qml.Hadamard(0)], [0, 1j/np.sqrt(2), 0, -1j/np.sqrt(2)]),
+        ([qml.PauliZ(0), qml.PauliZ(1)], [qml.Hadamard(1)], [1/np.sqrt(2), 1/np.sqrt(2), 0, 0]),
+    ])
+    def test_state_pauli_operations_and_observables(self, simulator_device_2_wires, ops, diag_ops, expected_pure_state, tol):
+        """Test that the state reflects Pauli operations and observable rotations correctly."""
+        simulator_device_2_wires.reset()
+        simulator_device_2_wires.apply(ops, rotations=diag_ops)
+
+        state = np.array(expected_pure_state)
+        expected_output = np.kron(state, state.conj()).reshape([4,4])
+
+        assert np.allclose(simulator_device_2_wires.state, expected_output, **tol)
+
+    @pytest.mark.parametrize("shots,analytic", [(100, False)])
+    def test_state_non_analytic(self, simulator_device_2_wires):
+        """Test that the state is None if in non-analytic mode."""
+        simulator_device_2_wires.reset()
+        simulator_device_2_wires.apply([qml.PauliX(0), qml.PauliX(1)])
+
+        assert simulator_device_2_wires.state is None

--- a/tests/test_native_ops.py
+++ b/tests/test_native_ops.py
@@ -59,9 +59,7 @@ class TestApply:
         simulator_device_1_wire._initial_state = np.array(input, dtype=np.complex64)
         simulator_device_1_wire.apply([ops.Depolarize(*par, wires=[0])])
 
-        assert np.allclose(
-            simulator_device_1_wire.state, expected_density_matrix, **tol
-        )
+        assert np.allclose(simulator_device_1_wire.state, expected_density_matrix, **tol)
 
     @pytest.mark.parametrize(
         "par,input,expected_density_matrix",
@@ -78,7 +76,7 @@ class TestApply:
             ([0.0], np.array([1, -1]) / np.sqrt(2), np.array([[1, -1], [-1, 1]]) / 2),
             ([0.5], np.array([1, -1]) / np.sqrt(2), np.array([[1, -1], [-1, 1]]) / 2),
             ([1.0], np.array([1, -1]) / np.sqrt(2), np.array([[1, -1], [-1, 1]]) / 2),
-        ]
+        ],
     )
     def test_apply_bit_flip_single_wire(
         self, simulator_device_1_wire, tol, par, input, expected_density_matrix
@@ -89,9 +87,7 @@ class TestApply:
         simulator_device_1_wire._initial_state = np.array(input, dtype=np.complex64)
         simulator_device_1_wire.apply([ops.BitFlip(*par, wires=[0])])
 
-        assert np.allclose(
-            simulator_device_1_wire.state, expected_density_matrix, **tol
-        )
+        assert np.allclose(simulator_device_1_wire.state, expected_density_matrix, **tol)
 
     @pytest.mark.parametrize(
         "par,input,expected_density_matrix",
@@ -108,7 +104,7 @@ class TestApply:
             ([0.0], np.array([1, -1]) / np.sqrt(2), np.array([[1, -1], [-1, 1]]) / 2),
             ([0.5], np.array([1, -1]) / np.sqrt(2), np.array([[1, 0], [0, 1]]) / 2),
             ([1.0], np.array([1, -1]) / np.sqrt(2), np.array([[1, 1], [1, 1]]) / 2),
-        ]
+        ],
     )
     def test_apply_phase_flip_single_wire(
         self, simulator_device_1_wire, tol, par, input, expected_density_matrix
@@ -119,10 +115,7 @@ class TestApply:
         simulator_device_1_wire._initial_state = np.array(input, dtype=np.complex64)
         simulator_device_1_wire.apply([ops.PhaseFlip(*par, wires=[0])])
 
-        assert np.allclose(
-            simulator_device_1_wire.state, expected_density_matrix, **tol
-        )
-
+        assert np.allclose(simulator_device_1_wire.state, expected_density_matrix, **tol)
 
     @pytest.mark.parametrize(
         "par,input,expected_density_matrix",
@@ -134,12 +127,20 @@ class TestApply:
             ([0.5], [0, 1], np.array([[0, 0], [0, 1]])),
             ([1.0], [0, 1], np.array([[0, 0], [0, 1]])),
             ([0.0], np.array([1, 1]) / np.sqrt(2), np.array([[1, 1], [1, 1]]) / 2),
-            ([0.5], np.array([1, 1]) / np.sqrt(2), np.array([[1, np.sqrt(1/2)], [np.sqrt(1/2), 1]]) / 2),
+            (
+                [0.5],
+                np.array([1, 1]) / np.sqrt(2),
+                np.array([[1, np.sqrt(1 / 2)], [np.sqrt(1 / 2), 1]]) / 2,
+            ),
             ([1.0], np.array([1, 1]) / np.sqrt(2), np.array([[1, 0], [0, 1]]) / 2),
             ([0.0], np.array([1, -1]) / np.sqrt(2), np.array([[1, -1], [-1, 1]]) / 2),
-            ([0.5], np.array([1, -1]) / np.sqrt(2), np.array([[1, -np.sqrt(1/2)], [-np.sqrt(1/2), 1]]) / 2),
+            (
+                [0.5],
+                np.array([1, -1]) / np.sqrt(2),
+                np.array([[1, -np.sqrt(1 / 2)], [-np.sqrt(1 / 2), 1]]) / 2,
+            ),
             ([1.0], np.array([1, -1]) / np.sqrt(2), np.array([[1, 0], [0, 1]]) / 2),
-        ]
+        ],
     )
     def test_apply_phase_damp_single_wire(
         self, simulator_device_1_wire, tol, par, input, expected_density_matrix
@@ -150,11 +151,8 @@ class TestApply:
         simulator_device_1_wire._initial_state = np.array(input, dtype=np.complex64)
         simulator_device_1_wire.apply([ops.PhaseDamp(*par, wires=[0])])
 
-        assert np.allclose(
-            simulator_device_1_wire.state, expected_density_matrix, **tol
-        )
-        
-    
+        assert np.allclose(simulator_device_1_wire.state, expected_density_matrix, **tol)
+
     @pytest.mark.parametrize(
         "par,input,expected_density_matrix",
         [
@@ -165,12 +163,20 @@ class TestApply:
             ([0.5], [0, 1], np.array([[1, 0], [0, 1]]) / 2),
             ([1.0], [0, 1], np.array([[1, 0], [0, 0]])),
             ([0.0], np.array([1, 1]) / np.sqrt(2), np.array([[1, 1], [1, 1]]) / 2),
-            ([0.5], np.array([1, 1]) / np.sqrt(2), np.array([[3 / 2, np.sqrt(1 / 2)], [np.sqrt(1 / 2), 1 / 2]]) / 2),
+            (
+                [0.5],
+                np.array([1, 1]) / np.sqrt(2),
+                np.array([[3 / 2, np.sqrt(1 / 2)], [np.sqrt(1 / 2), 1 / 2]]) / 2,
+            ),
             ([1.0], np.array([1, 1]) / np.sqrt(2), np.array([[1, 0], [0, 0]])),
             ([0.0], np.array([1, -1]) / np.sqrt(2), np.array([[1, -1], [-1, 1]]) / 2),
-            ([0.5], np.array([1, -1]) / np.sqrt(2), np.array([[3 / 2, -np.sqrt(1 / 2)], [-np.sqrt(1 / 2), 1 / 2]]) / 2),
+            (
+                [0.5],
+                np.array([1, -1]) / np.sqrt(2),
+                np.array([[3 / 2, -np.sqrt(1 / 2)], [-np.sqrt(1 / 2), 1 / 2]]) / 2,
+            ),
             ([1.0], np.array([1, -1]) / np.sqrt(2), np.array([[1, 0], [0, 0]])),
-        ]
+        ],
     )
     def test_apply_amplitude_damp_single_wire(
         self, simulator_device_1_wire, tol, par, input, expected_density_matrix
@@ -181,6 +187,4 @@ class TestApply:
         simulator_device_1_wire._initial_state = np.array(input, dtype=np.complex64)
         simulator_device_1_wire.apply([ops.AmplitudeDamp(*par, wires=[0])])
 
-        assert np.allclose(
-            simulator_device_1_wire.state, expected_density_matrix, **tol
-        )
+        assert np.allclose(simulator_device_1_wire.state, expected_density_matrix, **tol)

--- a/tests/test_native_ops.py
+++ b/tests/test_native_ops.py
@@ -29,72 +29,157 @@ def simulator_device_1_wire(shots, analytic):
     yield MixedStateSimulatorDevice(1, shots=shots, analytic=analytic)
 
 
-@pytest.fixture(scope="function")
-def simulator_device_2_wires(shots, analytic):
-    """Return a two wire instance of the MixedStateSimulatorDevice class."""
-    yield MixedStateSimulatorDevice(2, shots=shots, analytic=analytic)
-
-
-@pytest.fixture(scope="function")
-def simulator_device_3_wires(shots, analytic):
-    """Return a three wire instance of the MixedStateSimulatorDevice class."""
-    yield MixedStateSimulatorDevice(3, shots=shots, analytic=analytic)
-
-
 @pytest.mark.parametrize("shots,analytic", [(100, True)])
 class TestApply:
     """Tests that ops are correctly applied"""
 
     @pytest.mark.parametrize(
-        "op,par,input,expected_density_matrix",
+        "par,input,expected_density_matrix",
         [
-            (ops.BitFlip, [0.0], [1, 0], np.array([[1, 0], [0, 0]])),
-            (ops.BitFlip, [0.5], [1, 0], np.array([[1, 0], [0, 1]]) / 2),
-            (ops.BitFlip, [1.0], [1, 0], np.array([[0, 0], [0, 1]])),
-            (ops.BitFlip, [0.0], [0, 1], np.array([[0, 0], [0, 1]])),
-            (ops.BitFlip, [0.5], [0, 1], np.array([[1, 0], [0, 1]]) / 2),
-            (ops.BitFlip, [1.0], [0, 1], np.array([[1, 0], [0, 0]])),
-            (ops.BitFlip, [0.0], np.array([1, 1]) / np.sqrt(2), np.array([[1, 1], [1, 1]]) / 2),
-            (ops.BitFlip, [0.5], np.array([1, 1]) / np.sqrt(2), np.array([[1, 1], [1, 1]]) / 2),
-            (ops.BitFlip, [1.0], np.array([1, 1]) / np.sqrt(2), np.array([[1, 1], [1, 1]]) / 2),
-            (ops.BitFlip, [0.0], np.array([1, -1]) / np.sqrt(2), np.array([[1, -1], [-1, 1]]) / 2),
-            (ops.BitFlip, [0.5], np.array([1, -1]) / np.sqrt(2), np.array([[1, -1], [-1, 1]]) / 2),
-            (ops.BitFlip, [1.0], np.array([1, -1]) / np.sqrt(2), np.array([[1, -1], [-1, 1]]) / 2),
-            (ops.PhaseFlip, [0.0], [1, 0], np.array([[1, 0], [0, 0]])),
-            (ops.PhaseFlip, [0.5], [1, 0], np.array([[1, 0], [0, 0]])),
-            (ops.PhaseFlip, [1.0], [1, 0], np.array([[1, 0], [0, 0]])),
-            (ops.PhaseFlip, [0.0], [0, 1], np.array([[0, 0], [0, 1]])),
-            (ops.PhaseFlip, [0.5], [0, 1], np.array([[0, 0], [0, 1]])),
-            (ops.PhaseFlip, [1.0], [0, 1], np.array([[0, 0], [0, 1]])),
-            (ops.PhaseFlip, [0.0], np.array([1, 1]) / np.sqrt(2), np.array([[1, 1], [1, 1]]) / 2),
-            (ops.PhaseFlip, [0.5], np.array([1, 1]) / np.sqrt(2), np.array([[1, 0], [0, 1]]) / 2),
-            (ops.PhaseFlip, [1.0], np.array([1, 1]) / np.sqrt(2), np.array([[1, -1], [-1, 1]]) / 2),
-            (ops.PhaseFlip, [0.0], np.array([1, -1]) / np.sqrt(2), np.array([[1, -1], [-1, 1]]) / 2),
-            (ops.PhaseFlip, [0.5], np.array([1, -1]) / np.sqrt(2), np.array([[1, 0], [0, 1]]) / 2),
-            (ops.PhaseFlip, [1.0], np.array([1, -1]) / np.sqrt(2), np.array([[1, 1], [1, 1]]) / 2),
-            (ops.PhaseDamp, [0.0], [1, 0], np.array([[1, 0], [0, 0]])),
-            (ops.PhaseDamp, [0.5], [1, 0], np.array([[1, 0], [0, 0]])),
-            (ops.PhaseDamp, [1.0], [1, 0], np.array([[1, 0], [0, 0]])),
-            (ops.PhaseDamp, [0.0], [0, 1], np.array([[0, 0], [0, 1]])),
-            (ops.PhaseDamp, [0.5], [0, 1], np.array([[0, 0], [0, 1]])),
-            (ops.PhaseDamp, [1.0], [0, 1], np.array([[0, 0], [0, 1]])),
-            (ops.PhaseDamp, [0.0], np.array([1, 1]) / np.sqrt(2), np.array([[1, 1], [1, 1]]) / 2),
-            (ops.PhaseDamp, [0.5], np.array([1, 1]) / np.sqrt(2), np.array([[1, np.sqrt(1/2)], [np.sqrt(1/2), 1]]) / 2),
-            (ops.PhaseDamp, [1.0], np.array([1, 1]) / np.sqrt(2), np.array([[1, 0], [0, 1]]) / 2),
-            (ops.PhaseDamp, [0.0], np.array([1, -1]) / np.sqrt(2), np.array([[1, -1], [-1, 1]]) / 2),
-            (ops.PhaseDamp, [0.5], np.array([1, -1]) / np.sqrt(2), np.array([[1, -np.sqrt(1/2)], [-np.sqrt(1/2), 1]]) / 2),
-            (ops.PhaseDamp, [1.0], np.array([1, -1]) / np.sqrt(2), np.array([[1, 0], [0, 1]]) / 2),
+            ([0.0], [1, 0], np.array([[1, 0], [0, 0]])),
+            ([0.5], [1, 0], np.array([[2, 0], [0, 1]]) / 3),
+            ([1.0], [1, 0], np.array([[1, 0], [0, 2]]) / 3),
+            ([0.0], [0, 1], np.array([[0, 0], [0, 1]])),
+            ([0.5], [0, 1], np.array([[1, 0], [0, 2]]) / 3),
+            ([1.0], [0, 1], np.array([[2, 0], [0, 1]]) / 3),
+            ([0.0], np.array([1, 1]) / np.sqrt(2), np.array([[1, 1], [1, 1]]) / 2),
+            ([0.5], np.array([1, 1]) / np.sqrt(2), np.array([[3, 1], [1, 3]]) / 6),
+            ([1.0], np.array([1, 1]) / np.sqrt(2), np.array([[1, -1 / 3], [-1 / 3, 1]]) / 2),
+            ([0.0], np.array([1, -1]) / np.sqrt(2), np.array([[1, -1], [-1, 1]]) / 2),
+            ([0.5], np.array([1, -1]) / np.sqrt(2), np.array([[3, -1], [-1, 3]]) / 6),
+            ([1.0], np.array([1, -1]) / np.sqrt(2), np.array([[1, 1 / 3], [1 / 3, 1]]) / 2),
         ],
     )
-    def test_apply_operation_single_wire_with_parameters(
-        self, simulator_device_1_wire, tol, op, par, input, expected_density_matrix
+    def test_apply_depolarize_single_wire(
+        self, simulator_device_1_wire, tol, par, input, expected_density_matrix
     ):
-        """Tests that applying an operation yields the expected output state for single wire
-           operations that have parameters."""
+        """Tests that applying a depolarizing operation yields the expected output state for single wire."""
 
         simulator_device_1_wire.reset()
         simulator_device_1_wire._initial_state = np.array(input, dtype=np.complex64)
-        simulator_device_1_wire.apply([op(*par, wires=[0])])
+        simulator_device_1_wire.apply([ops.Depolarize(*par, wires=[0])])
+
+        assert np.allclose(
+            simulator_device_1_wire.state, expected_density_matrix, **tol
+        )
+
+    @pytest.mark.parametrize(
+        "par,input,expected_density_matrix",
+        [
+            ([0.0], [1, 0], np.array([[1, 0], [0, 0]])),
+            ([0.5], [1, 0], np.array([[1, 0], [0, 1]]) / 2),
+            ([1.0], [1, 0], np.array([[0, 0], [0, 1]])),
+            ([0.0], [0, 1], np.array([[0, 0], [0, 1]])),
+            ([0.5], [0, 1], np.array([[1, 0], [0, 1]]) / 2),
+            ([1.0], [0, 1], np.array([[1, 0], [0, 0]])),
+            ([0.0], np.array([1, 1]) / np.sqrt(2), np.array([[1, 1], [1, 1]]) / 2),
+            ([0.5], np.array([1, 1]) / np.sqrt(2), np.array([[1, 1], [1, 1]]) / 2),
+            ([1.0], np.array([1, 1]) / np.sqrt(2), np.array([[1, 1], [1, 1]]) / 2),
+            ([0.0], np.array([1, -1]) / np.sqrt(2), np.array([[1, -1], [-1, 1]]) / 2),
+            ([0.5], np.array([1, -1]) / np.sqrt(2), np.array([[1, -1], [-1, 1]]) / 2),
+            ([1.0], np.array([1, -1]) / np.sqrt(2), np.array([[1, -1], [-1, 1]]) / 2),
+        ]
+    )
+    def test_apply_bit_flip_single_wire(
+        self, simulator_device_1_wire, tol, par, input, expected_density_matrix
+    ):
+        """Tests that applying a bit flip operation yields the expected output state for single wire."""
+
+        simulator_device_1_wire.reset()
+        simulator_device_1_wire._initial_state = np.array(input, dtype=np.complex64)
+        simulator_device_1_wire.apply([ops.BitFlip(*par, wires=[0])])
+
+        assert np.allclose(
+            simulator_device_1_wire.state, expected_density_matrix, **tol
+        )
+
+    @pytest.mark.parametrize(
+        "par,input,expected_density_matrix",
+        [
+            ([0.0], [1, 0], np.array([[1, 0], [0, 0]])),
+            ([0.5], [1, 0], np.array([[1, 0], [0, 0]])),
+            ([1.0], [1, 0], np.array([[1, 0], [0, 0]])),
+            ([0.0], [0, 1], np.array([[0, 0], [0, 1]])),
+            ([0.5], [0, 1], np.array([[0, 0], [0, 1]])),
+            ([1.0], [0, 1], np.array([[0, 0], [0, 1]])),
+            ([0.0], np.array([1, 1]) / np.sqrt(2), np.array([[1, 1], [1, 1]]) / 2),
+            ([0.5], np.array([1, 1]) / np.sqrt(2), np.array([[1, 0], [0, 1]]) / 2),
+            ([1.0], np.array([1, 1]) / np.sqrt(2), np.array([[1, -1], [-1, 1]]) / 2),
+            ([0.0], np.array([1, -1]) / np.sqrt(2), np.array([[1, -1], [-1, 1]]) / 2),
+            ([0.5], np.array([1, -1]) / np.sqrt(2), np.array([[1, 0], [0, 1]]) / 2),
+            ([1.0], np.array([1, -1]) / np.sqrt(2), np.array([[1, 1], [1, 1]]) / 2),
+        ]
+    )
+    def test_apply_phase_flip_single_wire(
+        self, simulator_device_1_wire, tol, par, input, expected_density_matrix
+    ):
+        """Tests that applying a phase flip operation yields the expected output state for single wire."""
+
+        simulator_device_1_wire.reset()
+        simulator_device_1_wire._initial_state = np.array(input, dtype=np.complex64)
+        simulator_device_1_wire.apply([ops.PhaseFlip(*par, wires=[0])])
+
+        assert np.allclose(
+            simulator_device_1_wire.state, expected_density_matrix, **tol
+        )
+
+
+    @pytest.mark.parametrize(
+        "par,input,expected_density_matrix",
+        [
+            ([0.0], [1, 0], np.array([[1, 0], [0, 0]])),
+            ([0.5], [1, 0], np.array([[1, 0], [0, 0]])),
+            ([1.0], [1, 0], np.array([[1, 0], [0, 0]])),
+            ([0.0], [0, 1], np.array([[0, 0], [0, 1]])),
+            ([0.5], [0, 1], np.array([[0, 0], [0, 1]])),
+            ([1.0], [0, 1], np.array([[0, 0], [0, 1]])),
+            ([0.0], np.array([1, 1]) / np.sqrt(2), np.array([[1, 1], [1, 1]]) / 2),
+            ([0.5], np.array([1, 1]) / np.sqrt(2), np.array([[1, np.sqrt(1/2)], [np.sqrt(1/2), 1]]) / 2),
+            ([1.0], np.array([1, 1]) / np.sqrt(2), np.array([[1, 0], [0, 1]]) / 2),
+            ([0.0], np.array([1, -1]) / np.sqrt(2), np.array([[1, -1], [-1, 1]]) / 2),
+            ([0.5], np.array([1, -1]) / np.sqrt(2), np.array([[1, -np.sqrt(1/2)], [-np.sqrt(1/2), 1]]) / 2),
+            ([1.0], np.array([1, -1]) / np.sqrt(2), np.array([[1, 0], [0, 1]]) / 2),
+        ]
+    )
+    def test_apply_phase_damp_single_wire(
+        self, simulator_device_1_wire, tol, par, input, expected_density_matrix
+    ):
+        """Tests that applying a phase damping operation yields the expected output state for single wire."""
+
+        simulator_device_1_wire.reset()
+        simulator_device_1_wire._initial_state = np.array(input, dtype=np.complex64)
+        simulator_device_1_wire.apply([ops.PhaseDamp(*par, wires=[0])])
+
+        assert np.allclose(
+            simulator_device_1_wire.state, expected_density_matrix, **tol
+        )
+        
+    
+    @pytest.mark.parametrize(
+        "par,input,expected_density_matrix",
+        [
+            ([0.0], [1, 0], np.array([[1, 0], [0, 0]])),
+            ([0.5], [1, 0], np.array([[1, 0], [0, 0]])),
+            ([1.0], [1, 0], np.array([[1, 0], [0, 0]])),
+            ([0.0], [0, 1], np.array([[0, 0], [0, 1]])),
+            ([0.5], [0, 1], np.array([[1, 0], [0, 1]]) / 2),
+            ([1.0], [0, 1], np.array([[1, 0], [0, 0]])),
+            ([0.0], np.array([1, 1]) / np.sqrt(2), np.array([[1, 1], [1, 1]]) / 2),
+            ([0.5], np.array([1, 1]) / np.sqrt(2), np.array([[3 / 2, np.sqrt(1 / 2)], [np.sqrt(1 / 2), 1 / 2]]) / 2),
+            ([1.0], np.array([1, 1]) / np.sqrt(2), np.array([[1, 0], [0, 0]])),
+            ([0.0], np.array([1, -1]) / np.sqrt(2), np.array([[1, -1], [-1, 1]]) / 2),
+            ([0.5], np.array([1, -1]) / np.sqrt(2), np.array([[3 / 2, -np.sqrt(1 / 2)], [-np.sqrt(1 / 2), 1 / 2]]) / 2),
+            ([1.0], np.array([1, -1]) / np.sqrt(2), np.array([[1, 0], [0, 0]])),
+        ]
+    )
+    def test_apply_amplitude_damp_single_wire(
+        self, simulator_device_1_wire, tol, par, input, expected_density_matrix
+    ):
+        """Tests that applying an amplitude damping operation yields the expected output state for single wire."""
+
+        simulator_device_1_wire.reset()
+        simulator_device_1_wire._initial_state = np.array(input, dtype=np.complex64)
+        simulator_device_1_wire.apply([ops.AmplitudeDamp(*par, wires=[0])])
 
         assert np.allclose(
             simulator_device_1_wire.state, expected_density_matrix, **tol

--- a/tests/test_native_ops.py
+++ b/tests/test_native_ops.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Unit tests for the native Cirq ops
+Tests for the native Cirq ops
 """
 import pytest
 import math

--- a/tests/test_native_ops.py
+++ b/tests/test_native_ops.py
@@ -1,0 +1,101 @@
+# Copyright 2018 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Unit tests for the native Cirq ops
+"""
+import pytest
+import math
+
+import pennylane as qml
+import numpy as np
+from pennylane_cirq import ops, MixedStateSimulatorDevice
+import cirq
+
+
+@pytest.fixture(scope="function")
+def simulator_device_1_wire(shots, analytic):
+    """Return a single wire instance of the MixedStateSimulatorDevice class."""
+    yield MixedStateSimulatorDevice(1, shots=shots, analytic=analytic)
+
+
+@pytest.fixture(scope="function")
+def simulator_device_2_wires(shots, analytic):
+    """Return a two wire instance of the MixedStateSimulatorDevice class."""
+    yield MixedStateSimulatorDevice(2, shots=shots, analytic=analytic)
+
+
+@pytest.fixture(scope="function")
+def simulator_device_3_wires(shots, analytic):
+    """Return a three wire instance of the MixedStateSimulatorDevice class."""
+    yield MixedStateSimulatorDevice(3, shots=shots, analytic=analytic)
+
+
+@pytest.mark.parametrize("shots,analytic", [(100, True)])
+class TestApply:
+    """Tests that ops are correctly applied"""
+
+    @pytest.mark.parametrize(
+        "op,par,input,expected_density_matrix",
+        [
+            (ops.BitFlip, [0.0], [1, 0], np.array([[1, 0], [0, 0]])),
+            (ops.BitFlip, [0.5], [1, 0], np.array([[1, 0], [0, 1]]) / 2),
+            (ops.BitFlip, [1.0], [1, 0], np.array([[0, 0], [0, 1]])),
+            (ops.BitFlip, [0.0], [0, 1], np.array([[0, 0], [0, 1]])),
+            (ops.BitFlip, [0.5], [0, 1], np.array([[1, 0], [0, 1]]) / 2),
+            (ops.BitFlip, [1.0], [0, 1], np.array([[1, 0], [0, 0]])),
+            (ops.BitFlip, [0.0], np.array([1, 1]) / np.sqrt(2), np.array([[1, 1], [1, 1]]) / 2),
+            (ops.BitFlip, [0.5], np.array([1, 1]) / np.sqrt(2), np.array([[1, 1], [1, 1]]) / 2),
+            (ops.BitFlip, [1.0], np.array([1, 1]) / np.sqrt(2), np.array([[1, 1], [1, 1]]) / 2),
+            (ops.BitFlip, [0.0], np.array([1, -1]) / np.sqrt(2), np.array([[1, -1], [-1, 1]]) / 2),
+            (ops.BitFlip, [0.5], np.array([1, -1]) / np.sqrt(2), np.array([[1, -1], [-1, 1]]) / 2),
+            (ops.BitFlip, [1.0], np.array([1, -1]) / np.sqrt(2), np.array([[1, -1], [-1, 1]]) / 2),
+            (ops.PhaseFlip, [0.0], [1, 0], np.array([[1, 0], [0, 0]])),
+            (ops.PhaseFlip, [0.5], [1, 0], np.array([[1, 0], [0, 0]])),
+            (ops.PhaseFlip, [1.0], [1, 0], np.array([[1, 0], [0, 0]])),
+            (ops.PhaseFlip, [0.0], [0, 1], np.array([[0, 0], [0, 1]])),
+            (ops.PhaseFlip, [0.5], [0, 1], np.array([[0, 0], [0, 1]])),
+            (ops.PhaseFlip, [1.0], [0, 1], np.array([[0, 0], [0, 1]])),
+            (ops.PhaseFlip, [0.0], np.array([1, 1]) / np.sqrt(2), np.array([[1, 1], [1, 1]]) / 2),
+            (ops.PhaseFlip, [0.5], np.array([1, 1]) / np.sqrt(2), np.array([[1, 0], [0, 1]]) / 2),
+            (ops.PhaseFlip, [1.0], np.array([1, 1]) / np.sqrt(2), np.array([[1, -1], [-1, 1]]) / 2),
+            (ops.PhaseFlip, [0.0], np.array([1, -1]) / np.sqrt(2), np.array([[1, -1], [-1, 1]]) / 2),
+            (ops.PhaseFlip, [0.5], np.array([1, -1]) / np.sqrt(2), np.array([[1, 0], [0, 1]]) / 2),
+            (ops.PhaseFlip, [1.0], np.array([1, -1]) / np.sqrt(2), np.array([[1, 1], [1, 1]]) / 2),
+            (ops.PhaseDamp, [0.0], [1, 0], np.array([[1, 0], [0, 0]])),
+            (ops.PhaseDamp, [0.5], [1, 0], np.array([[1, 0], [0, 0]])),
+            (ops.PhaseDamp, [1.0], [1, 0], np.array([[1, 0], [0, 0]])),
+            (ops.PhaseDamp, [0.0], [0, 1], np.array([[0, 0], [0, 1]])),
+            (ops.PhaseDamp, [0.5], [0, 1], np.array([[0, 0], [0, 1]])),
+            (ops.PhaseDamp, [1.0], [0, 1], np.array([[0, 0], [0, 1]])),
+            (ops.PhaseDamp, [0.0], np.array([1, 1]) / np.sqrt(2), np.array([[1, 1], [1, 1]]) / 2),
+            (ops.PhaseDamp, [0.5], np.array([1, 1]) / np.sqrt(2), np.array([[1, np.sqrt(1/2)], [np.sqrt(1/2), 1]]) / 2),
+            (ops.PhaseDamp, [1.0], np.array([1, 1]) / np.sqrt(2), np.array([[1, 0], [0, 1]]) / 2),
+            (ops.PhaseDamp, [0.0], np.array([1, -1]) / np.sqrt(2), np.array([[1, -1], [-1, 1]]) / 2),
+            (ops.PhaseDamp, [0.5], np.array([1, -1]) / np.sqrt(2), np.array([[1, -np.sqrt(1/2)], [-np.sqrt(1/2), 1]]) / 2),
+            (ops.PhaseDamp, [1.0], np.array([1, -1]) / np.sqrt(2), np.array([[1, 0], [0, 1]]) / 2),
+        ],
+    )
+    def test_apply_operation_single_wire_with_parameters(
+        self, simulator_device_1_wire, tol, op, par, input, expected_density_matrix
+    ):
+        """Tests that applying an operation yields the expected output state for single wire
+           operations that have parameters."""
+
+        simulator_device_1_wire.reset()
+        simulator_device_1_wire._initial_state = np.array(input, dtype=np.complex64)
+        simulator_device_1_wire.apply([op(*par, wires=[0])])
+
+        assert np.allclose(
+            simulator_device_1_wire.state, expected_density_matrix, **tol
+        )

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -85,14 +85,10 @@ class TestSample:
         assert np.allclose(sorted(list(set(s1))), sorted(eigvals), **tol)
 
         # the analytic mean is 2*sin(theta)+0.5*cos(theta)+0.5
-        assert np.allclose(
-            np.mean(s1), 2 * np.sin(theta) + 0.5 * np.cos(theta) + 0.5, **tol
-        )
+        assert np.allclose(np.mean(s1), 2 * np.sin(theta) + 0.5 * np.cos(theta) + 0.5, **tol)
 
         # the analytic variance is 0.25*(sin(theta)-4*cos(theta))^2
-        assert np.allclose(
-            np.var(s1), 0.25 * (np.sin(theta) - 4 * np.cos(theta)) ** 2, **tol
-        )
+        assert np.allclose(np.var(s1), 0.25 * (np.sin(theta) - 4 * np.cos(theta)) ** 2, **tol)
 
     def test_sample_values_hermitian_multi_qubit(self, device, shots, tol):
         """Tests if the samples of a multi-qubit Hermitian observable returned by sample have
@@ -112,11 +108,7 @@ class TestSample:
 
         with mimic_execution_for_sample(dev):
             dev.apply(
-                [
-                    qml.RX(theta, wires=[0]),
-                    qml.RY(2 * theta, wires=[1]),
-                    qml.CNOT(wires=[0, 1]),
-                ],
+                [qml.RX(theta, wires=[0]), qml.RY(2 * theta, wires=[1]), qml.CNOT(wires=[0, 1]),],
                 rotations=qml.Hermitian(A, wires=[0, 1], do_queue=False).diagonalizing_gates(),
             )
 
@@ -156,9 +148,7 @@ class TestTensorSample:
         varphi = -0.543
 
         dev = device(3)
-        obs = qml.PauliX(wires=[0], do_queue=False) @ qml.PauliY(
-            wires=[2], do_queue=False
-        )
+        obs = qml.PauliX(wires=[0], do_queue=False) @ qml.PauliY(wires=[2], do_queue=False)
 
         with mimic_execution_for_sample(dev):
             dev.apply(
@@ -224,9 +214,7 @@ class TestTensorSample:
         assert np.allclose(s1 ** 2, 1, **tol)
 
         mean = np.mean(s1)
-        expected = -(
-            np.cos(varphi) * np.sin(phi) + np.sin(varphi) * np.cos(theta)
-        ) / np.sqrt(2)
+        expected = -(np.cos(varphi) * np.sin(phi) + np.sin(varphi) * np.cos(theta)) / np.sqrt(2)
         assert np.allclose(mean, expected, **tol)
 
         var = np.var(s1)
@@ -258,9 +246,7 @@ class TestTensorSample:
             ]
         )
 
-        obs = qml.PauliZ(wires=[0], do_queue=False) @ qml.Hermitian(
-            A, wires=[1, 2], do_queue=False
-        )
+        obs = qml.PauliZ(wires=[0], do_queue=False) @ qml.Hermitian(A, wires=[1, 2], do_queue=False)
 
         with mimic_execution_for_sample(dev):
             dev.apply(
@@ -296,10 +282,7 @@ class TestTensorSample:
             1057
             - np.cos(2 * phi)
             + 12 * (27 + np.cos(2 * phi)) * np.cos(varphi)
-            - 2
-            * np.cos(2 * varphi)
-            * np.sin(phi)
-            * (16 * np.cos(phi) + 21 * np.sin(phi))
+            - 2 * np.cos(2 * varphi) * np.sin(phi) * (16 * np.cos(phi) + 21 * np.sin(phi))
             + 16 * np.sin(2 * phi)
             - 8 * (-17 + np.cos(2 * phi) + 2 * np.sin(2 * phi)) * np.sin(varphi)
             - 8 * np.cos(2 * theta) * (3 + 3 * np.cos(varphi) + np.sin(varphi)) ** 2

--- a/tests/test_simulator_device.py
+++ b/tests/test_simulator_device.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Unit tests for the Simulator plugin
+Unit tests for the SimulatorDevice
 """
 import pytest
 import math

--- a/tests/test_simulator_device.py
+++ b/tests/test_simulator_device.py
@@ -95,9 +95,7 @@ class TestApply:
         simulator_device_1_wire._initial_state = np.array(input, dtype=np.complex64)
         simulator_device_1_wire.apply([op(wires=[0])])
 
-        assert np.allclose(
-            simulator_device_1_wire.state, np.array(expected_output), **tol
-        )
+        assert np.allclose(simulator_device_1_wire.state, np.array(expected_output), **tol)
 
     @pytest.mark.parametrize(
         "op,input,expected_output",
@@ -135,9 +133,7 @@ class TestApply:
         simulator_device_2_wires._initial_state = np.array(input, dtype=np.complex64)
         simulator_device_2_wires.apply([op(wires=[0, 1])])
 
-        assert np.allclose(
-            simulator_device_2_wires.state, np.array(expected_output), **tol
-        )
+        assert np.allclose(simulator_device_2_wires.state, np.array(expected_output), **tol)
 
     @pytest.mark.parametrize(
         "op,expected_output,par",
@@ -169,9 +165,7 @@ class TestApply:
         simulator_device_2_wires.reset()
         simulator_device_2_wires.apply([op(np.array(par), wires=[0, 1])])
 
-        assert np.allclose(
-            simulator_device_2_wires.state, np.array(expected_output), **tol
-        )
+        assert np.allclose(simulator_device_2_wires.state, np.array(expected_output), **tol)
 
     @pytest.mark.parametrize(
         "op,input,expected_output,par",
@@ -203,18 +197,8 @@ class TestApply:
                 [1 / 2 - 1j / 2, 1 / 2 + 1j / 2],
                 [math.pi / 2],
             ),
-            (
-                qml.Rot,
-                [1, 0],
-                [1 / math.sqrt(2) - 1j / math.sqrt(2), 0],
-                [math.pi / 2, 0, 0],
-            ),
-            (
-                qml.Rot,
-                [1, 0],
-                [1 / math.sqrt(2), 1 / math.sqrt(2)],
-                [0, math.pi / 2, 0],
-            ),
+            (qml.Rot, [1, 0], [1 / math.sqrt(2) - 1j / math.sqrt(2), 0], [math.pi / 2, 0, 0],),
+            (qml.Rot, [1, 0], [1 / math.sqrt(2), 1 / math.sqrt(2)], [0, math.pi / 2, 0],),
             (
                 qml.Rot,
                 [1 / math.sqrt(2), 1 / math.sqrt(2)],
@@ -284,9 +268,7 @@ class TestApply:
         simulator_device_1_wire._initial_state = np.array(input, dtype=np.complex64)
         simulator_device_1_wire.apply([op(*par, wires=[0])])
 
-        assert np.allclose(
-            simulator_device_1_wire.state, np.array(expected_output), **tol
-        )
+        assert np.allclose(simulator_device_1_wire.state, np.array(expected_output), **tol)
 
     @pytest.mark.parametrize(
         "op,input,expected_output,par",
@@ -299,12 +281,7 @@ class TestApply:
                 [0, 1 / math.sqrt(2), 1 / 2, -1j / 2],
                 [math.pi / 2],
             ),
-            (
-                qml.CRY,
-                [0, 0, 0, 1],
-                [0, 0, -1 / math.sqrt(2), 1 / math.sqrt(2)],
-                [math.pi / 2],
-            ),
+            (qml.CRY, [0, 0, 0, 1], [0, 0, -1 / math.sqrt(2), 1 / math.sqrt(2)], [math.pi / 2],),
             (qml.CRY, [0, 0, 0, 1], [0, 0, -1, 0], [math.pi]),
             (
                 qml.CRY,
@@ -412,9 +389,7 @@ class TestApply:
         simulator_device_2_wires._initial_state = np.array(input, dtype=np.complex64)
         simulator_device_2_wires.apply([op(*par, wires=[0, 1])])
 
-        assert np.allclose(
-            simulator_device_2_wires.state, np.array(expected_output), **tol
-        )
+        assert np.allclose(simulator_device_2_wires.state, np.array(expected_output), **tol)
 
     @pytest.mark.parametrize(
         "operation,par,match",
@@ -463,9 +438,7 @@ class TestApply:
             ),
         ],
     )
-    def test_state_preparation_error(
-        self, simulator_device_1_wire, operation, par, match
-    ):
+    def test_state_preparation_error(self, simulator_device_1_wire, operation, par, match):
         """Tests that the state preparation routines raise proper errors for wrong parameter values."""
 
         simulator_device_1_wire.reset()
@@ -483,9 +456,7 @@ class TestApply:
             qml.DeviceError,
             match="The operation BasisState is only supported at the beginning of a circuit.",
         ):
-            simulator_device_1_wire.apply(
-                [qml.PauliX(0), qml.BasisState(np.array([0]), wires=[0])]
-            )
+            simulator_device_1_wire.apply([qml.PauliX(0), qml.BasisState(np.array([0]), wires=[0])])
 
     def test_qubit_state_vector_not_at_beginning_error(self, simulator_device_1_wire):
         """Tests that application of QubitStateVector raises an error if is not
@@ -513,8 +484,7 @@ class TestStatePreparationErrorsNonAnalytic:
         simulator_device_1_wire.reset()
 
         with pytest.raises(
-            qml.DeviceError,
-            match="The operation BasisState is only supported in analytic mode.",
+            qml.DeviceError, match="The operation BasisState is only supported in analytic mode.",
         ):
             simulator_device_1_wire.apply([qml.BasisState(np.array([0]), wires=[0])])
 
@@ -528,9 +498,8 @@ class TestStatePreparationErrorsNonAnalytic:
             qml.DeviceError,
             match="The operation QubitStateVector is only supported in analytic mode.",
         ):
-            simulator_device_1_wire.apply(
-                [qml.QubitStateVector(np.array([0, 1]), wires=[0])]
-            )
+            simulator_device_1_wire.apply([qml.QubitStateVector(np.array([0, 1]), wires=[0])])
+
 
 @pytest.mark.parametrize("shots,analytic", [(100, True)])
 class TestAnalyticProbability:
@@ -543,6 +512,7 @@ class TestAnalyticProbability:
         simulator_device_1_wire.reset()
         assert simulator_device_1_wire._state is None
         assert simulator_device_1_wire.analytic_probability() is None
+
 
 @pytest.mark.parametrize("shots,analytic", [(100, True)])
 class TestExpval:
@@ -626,51 +596,25 @@ class TestExpval:
                 qml.Hermitian,
                 [1 / math.sqrt(3), 0, 1 / math.sqrt(3), 1 / math.sqrt(3)],
                 5 / 3,
-                [
-                    np.array(
-                        [[1, 1j, 0, 1], [-1j, 1, 0, 0], [0, 0, 1, -1j], [1, 0, 1j, 1]]
-                    )
-                ],
+                [np.array([[1, 1j, 0, 1], [-1j, 1, 0, 0], [0, 0, 1, -1j], [1, 0, 1j, 1]])],
             ),
             (
                 qml.Hermitian,
                 [0, 0, 0, 1],
                 0,
-                [
-                    np.array(
-                        [[0, 1j, 0, 0], [-1j, 0, 0, 0], [0, 0, 0, -1j], [0, 0, 1j, 0]]
-                    )
-                ],
+                [np.array([[0, 1j, 0, 0], [-1j, 0, 0, 0], [0, 0, 0, -1j], [0, 0, 1j, 0]])],
             ),
             (
                 qml.Hermitian,
                 [1 / math.sqrt(2), 0, -1 / math.sqrt(2), 0],
                 1,
-                [
-                    np.array(
-                        [[1, 1j, 0, 0], [-1j, 1, 0, 0], [0, 0, 1, -1j], [0, 0, 1j, 1]]
-                    )
-                ],
+                [np.array([[1, 1j, 0, 0], [-1j, 1, 0, 0], [0, 0, 1, -1j], [0, 0, 1j, 1]])],
             ),
             (
                 qml.Hermitian,
-                [
-                    1 / math.sqrt(3),
-                    -1 / math.sqrt(3),
-                    1 / math.sqrt(6),
-                    1 / math.sqrt(6),
-                ],
+                [1 / math.sqrt(3), -1 / math.sqrt(3), 1 / math.sqrt(6), 1 / math.sqrt(6),],
                 1,
-                [
-                    np.array(
-                        [
-                            [1, 1j, 0, 0.5j],
-                            [-1j, 1, 0, 0],
-                            [0, 0, 1, -1j],
-                            [-0.5j, 0, 1j, 1],
-                        ]
-                    )
-                ],
+                [np.array([[1, 1j, 0, 0.5j], [-1j, 1, 0, 0], [0, 0, 1, -1j], [-0.5j, 0, 1j, 1],])],
             ),
             (
                 qml.Hermitian,
@@ -750,12 +694,7 @@ class TestVar:
             (qml.Identity, [1 / math.sqrt(2), -1 / math.sqrt(2)], 0, []),
             (qml.Hermitian, [1, 0], 1, [[[1, 1j], [-1j, 1]]]),
             (qml.Hermitian, [0, 1], 1, [[[1, 1j], [-1j, 1]]]),
-            (
-                qml.Hermitian,
-                [1 / math.sqrt(2), -1 / math.sqrt(2)],
-                1,
-                [[[1, 1j], [-1j, 1]]],
-            ),
+            (qml.Hermitian, [1 / math.sqrt(2), -1 / math.sqrt(2)], 1, [[[1, 1j], [-1j, 1]]],),
         ],
     )
     def test_var_single_wire_with_parameters(
@@ -862,9 +801,7 @@ class TestSample:
         the correct dimensions
         """
         simulator_device_2_wires.reset()
-        simulator_device_2_wires.apply(
-            [qml.RX(1.5708, wires=[0]), qml.RX(1.5708, wires=[1])]
-        )
+        simulator_device_2_wires.apply([qml.RX(1.5708, wires=[0]), qml.RX(1.5708, wires=[1])])
 
         simulator_device_2_wires.shots = 10
         simulator_device_2_wires._samples = simulator_device_2_wires.generate_samples()
@@ -878,9 +815,7 @@ class TestSample:
 
         simulator_device_2_wires.shots = 17
         simulator_device_2_wires._samples = simulator_device_2_wires.generate_samples()
-        s3 = simulator_device_2_wires.sample(
-            qml.Hermitian(np.diag([1, 1, 1, -1]), wires=[0, 1])
-        )
+        s3 = simulator_device_2_wires.sample(qml.Hermitian(np.diag([1, 1, 1, -1]), wires=[0, 1]))
         assert np.array_equal(s3.shape, (17,))
 
     def test_sample_values(self, simulator_device_2_wires, tol):
@@ -904,11 +839,14 @@ class TestState:
     """Test the state property."""
 
     @pytest.mark.parametrize("shots,analytic", [(100, True)])
-    @pytest.mark.parametrize("ops,expected_state", [
-        ([qml.PauliX(0), qml.PauliX(1)], [0, 0, 0, 1]),
-        ([qml.PauliX(0), qml.PauliY(1)], [0, 0, 0, 1j]),
-        ([qml.PauliZ(0), qml.PauliZ(1)], [1, 0, 0, 0]),
-    ])
+    @pytest.mark.parametrize(
+        "ops,expected_state",
+        [
+            ([qml.PauliX(0), qml.PauliX(1)], [0, 0, 0, 1]),
+            ([qml.PauliX(0), qml.PauliY(1)], [0, 0, 0, 1j]),
+            ([qml.PauliZ(0), qml.PauliZ(1)], [1, 0, 0, 0]),
+        ],
+    )
     def test_state_pauli_operations(self, simulator_device_2_wires, ops, expected_state, tol):
         """Test that the state reflects Pauli operations correctly."""
         simulator_device_2_wires.reset()
@@ -917,12 +855,25 @@ class TestState:
         assert np.allclose(simulator_device_2_wires.state, expected_state, **tol)
 
     @pytest.mark.parametrize("shots,analytic", [(100, True)])
-    @pytest.mark.parametrize("ops,diag_ops,expected_state", [
-        ([qml.PauliX(0), qml.PauliX(1)], [], [0, 0, 0, 1]),
-        ([qml.PauliX(0), qml.PauliY(1)], [qml.Hadamard(0)], [0, 1j/np.sqrt(2), 0, -1j/np.sqrt(2)]),
-        ([qml.PauliZ(0), qml.PauliZ(1)], [qml.Hadamard(1)], [1/np.sqrt(2), 1/np.sqrt(2), 0, 0]),
-    ])
-    def test_state_pauli_operations_and_observables(self, simulator_device_2_wires, ops, diag_ops, expected_state, tol):
+    @pytest.mark.parametrize(
+        "ops,diag_ops,expected_state",
+        [
+            ([qml.PauliX(0), qml.PauliX(1)], [], [0, 0, 0, 1]),
+            (
+                [qml.PauliX(0), qml.PauliY(1)],
+                [qml.Hadamard(0)],
+                [0, 1j / np.sqrt(2), 0, -1j / np.sqrt(2)],
+            ),
+            (
+                [qml.PauliZ(0), qml.PauliZ(1)],
+                [qml.Hadamard(1)],
+                [1 / np.sqrt(2), 1 / np.sqrt(2), 0, 0],
+            ),
+        ],
+    )
+    def test_state_pauli_operations_and_observables(
+        self, simulator_device_2_wires, ops, diag_ops, expected_state, tol
+    ):
         """Test that the state reflects Pauli operations and observable rotations correctly."""
         simulator_device_2_wires.reset()
         simulator_device_2_wires.apply(ops, rotations=diag_ops)

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -53,9 +53,7 @@ class TestVar:
 
         # Here the observable is already diagonal
         var = dev.var(qml.PauliZ(wires=[0], do_queue=False))
-        expected = 0.25 * (
-            3 - np.cos(2 * theta) - 2 * np.cos(theta) ** 2 * np.cos(2 * phi)
-        )
+        expected = 0.25 * (3 - np.cos(2 * theta) - 2 * np.cos(theta) ** 2 * np.cos(2 * phi))
 
         assert np.allclose(var, expected, **tol)
 
@@ -99,9 +97,7 @@ class TestTensorVar:
         varphi = -0.543
 
         dev = device(3)
-        obs = qml.PauliX(wires=[0], do_queue=False) @ qml.PauliY(
-            wires=[2], do_queue=False
-        )
+        obs = qml.PauliX(wires=[0], do_queue=False) @ qml.PauliY(wires=[2], do_queue=False)
 
         with mimic_execution_for_var(dev):
             dev.apply(
@@ -181,9 +177,7 @@ class TestTensorVar:
                 [-5 - 2j, -5 - 4j, -4 - 3j, -6],
             ]
         )
-        obs = qml.PauliZ(wires=[0], do_queue=False) @ qml.Hermitian(
-            A, wires=[1, 2], do_queue=False
-        )
+        obs = qml.PauliZ(wires=[0], do_queue=False) @ qml.Hermitian(A, wires=[1, 2], do_queue=False)
 
         with mimic_execution_for_var(dev):
             dev.apply(
@@ -203,10 +197,7 @@ class TestTensorVar:
             1057
             - np.cos(2 * phi)
             + 12 * (27 + np.cos(2 * phi)) * np.cos(varphi)
-            - 2
-            * np.cos(2 * varphi)
-            * np.sin(phi)
-            * (16 * np.cos(phi) + 21 * np.sin(phi))
+            - 2 * np.cos(2 * varphi) * np.sin(phi) * (16 * np.cos(phi) + 21 * np.sin(phi))
             + 16 * np.sin(2 * phi)
             - 8 * (-17 + np.cos(2 * phi) + 2 * np.sin(2 * phi)) * np.sin(varphi)
             - 8 * np.cos(2 * theta) * (3 + 3 * np.cos(varphi) + np.sin(varphi)) ** 2


### PR DESCRIPTION
Adds a new `"cirq.mixedsimulator"` class to Cirq, which uses Cirq's `DensityMatrixSimulator` as a backend. Added a number of new ops which can only run on this device.

Also undertook a bit of general clean up while I was working in the repo.

Open questions I came across while working on this. Any thoughts are appreciated.

1. Why are state initialization ops only supported in analytic mode? As far as I can tell, these could still be supported in "non-analytic" mode
2. There is a comment indicating a discrepency between the `state` method returned by `default.qubit` and this plugin. I'm not sure why they weren't brought into alignment
3. ``test_sample_values_hermitian_multi_qubit`` in `test_samples.py` is dependent on the rng seed (if you add more tests, it can cause this one to fail). Should we update?
4. Some of the new ops could actually be supported on the pure state simulator (they are monte-carlo style and select one path with each execution). So expectation values could still be obtained by running many trials. I think the logic built into ``QubitDevice`` makes some assumptions which prevent us from using those properly though :thinking: 
5. Should we add tests for cirq gate arguments, e.g., a channel parameter falls in the correct range? (I was content to leave error messages to Cirq)
6. Should we take this opportunity to add further Cirq native gates (I only added channels)