### PR TITLE
Update requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ dist: xenial
 python:
   - 3.6
   - 3.7
+  - 3.8
 install:
   - pip install pip --upgrade
   - pip install -e git+https://github.com/XanaduAI/pennylane.git#egg=pennylane

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
   - 3.7
 install:
   - pip install pip --upgrade
-  - pip install networkx==2.3
   - pip install -e git+https://github.com/XanaduAI/pennylane.git#egg=pennylane
   - pip install -r requirements.txt
   - pip install pytest pytest-cov wheel codecov --upgrade

--- a/README.rst
+++ b/README.rst
@@ -33,14 +33,14 @@ PennyLane-Cirq Plugin
 The PennyLane-Cirq plugin integrates the Cirq quantum computing framework with PennyLane's
 quantum machine learning capabilities.
 
-`PennyLane <https://pennylane.readthedocs.io>`_ is a cross-platform Python library for quantum machine
+`PennyLane <https://pennylane.readthedocs.io>`__ is a cross-platform Python library for quantum machine
 learning, automatic differentiation, and optimization of hybrid quantum-classical computations.
 
-`Cirq <https://github.com/quantumlib/Cirq>`_ is a software library for quantum computing.
+`Cirq <https://github.com/quantumlib/Cirq>`__ is a software library for quantum computing.
 
 .. header-end-inclusion-marker-do-not-remove
 
-The plugin documentation can be found here: `<https://pennylane-cirq.readthedocs.io/en/latest/>`_.
+The plugin documentation can be found here: `<https://pennylane-cirq.readthedocs.io/en/latest/>`__.
 
 Features
 ========
@@ -54,14 +54,14 @@ Features
 Installation
 ============
 
-This plugin requires Python version 3.5 and above, as well as PennyLane
+This plugin requires Python version 3.6 or above, as well as PennyLane
 and Cirq. Installation of this plugin, as well as all dependencies, can be done using ``pip``:
 
 .. code-block:: bash
 
     $ pip install pennylane-cirq
 
-Alternatively, you can install PennyLane-Cirq from the `source code <https://github.com/XanaduAI/pennylane-cirq>`_
+Alternatively, you can install PennyLane-Cirq from the `source code <https://github.com/XanaduAI/pennylane-cirq>`__
 by navigating to the top directory and running:
 
 	$ python setup.py install
@@ -71,16 +71,16 @@ Dependencies
 
 PennyLane-Cirq requires the following libraries be installed:
 
-* `Python <http://python.org/>`_ >=3.5
+* `Python <http://python.org/>`__ >= 3.6
 
 as well as the following Python packages:
 
-* `PennyLane <http://pennylane.readthedocs.io/>`_ >=0.6
-* `Cirq <https://cirq.readthedocs.io/>`_ >= 0.6
+* `PennyLane <http://pennylane.readthedocs.io/>`__ >= 0.9
+* `Cirq <https://cirq.readthedocs.io/>`__ >= 0.7
 
 
 If you currently do not have Python 3 installed, we recommend
-`Anaconda for Python 3 <https://www.anaconda.com/download/>`_, a distributed version of Python packaged
+`Anaconda for Python 3 <https://www.anaconda.com/download/>`__, a distributed version of Python packaged
 for scientific computation.
 
 
@@ -103,7 +103,7 @@ To build the HTML documentation, go to the top-level directory and run:
   $ make docs
 
 
-The documentation can then be found in the :file:`doc/_build/html/` directory.
+The documentation can then be found in the ``doc/_build/html/`` directory.
 
 .. installation-end-inclusion-marker-do-not-remove
 
@@ -111,7 +111,7 @@ Contributing
 ============
 
 We welcome contributions - simply fork the repository of this plugin, and then make a
-`pull request <https://help.github.com/articles/about-pull-requests/>`_ containing your contribution.
+`pull request <https://help.github.com/articles/about-pull-requests/>`__ containing your contribution.
 All contributers to this plugin will be listed as authors on the releases.
 
 We also encourage bug reports, suggestions for new features and enhancements, and even links to cool projects
@@ -120,9 +120,9 @@ or applications built on PennyLane.
 Authors
 =======
 
-PennyLane-Cirq is the work of `many contributors <https://github.com/XanaduAI/pennylane-cirq/graphs/contributors>`_.
+PennyLane-Cirq is the work of `many contributors <https://github.com/XanaduAI/pennylane-cirq/graphs/contributors>`__.
 
-If you are doing research using PennyLane and PennyLane-Cirq, please cite `our paper <https://arxiv.org/abs/1811.04968>`_:
+If you are doing research using PennyLane and PennyLane-Cirq, please cite `our paper <https://arxiv.org/abs/1811.04968>`__:
 
     Ville Bergholm, Josh Izaac, Maria Schuld, Christian Gogolin, M. Sohaib Alam, Shahnawaz Ahmed,
     Juan Miguel Arrazola, Carsten Blank, Alain Delgado, Soran Jahangiri, Keri McKiernan, Johannes Jakob Meyer,
@@ -148,6 +148,6 @@ License
 =======
 
 The PennyLane-Cirq plugin is **free** and **open source**, released under
-the `Apache License, Version 2.0 <https://www.apache.org/licenses/LICENSE-2.0>`_.
+the `Apache License, Version 2.0 <https://www.apache.org/licenses/LICENSE-2.0>`__.
 
 .. license-end-inclusion-marker-do-not-remove

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ PennyLane-Cirq Plugin
     :alt: PyPI
     :target: https://pypi.org/project/pennylane-cirq
 
-.. image:: doc/_static/puzzle_cirq.png
+.. image:: https://github.com/XanaduAI/pennylane-cirq/blob/master/doc/_static/puzzle_cirq.png?raw=true
     :align: center
     :width: 200px
     :target: javascript:void(0);

--- a/pennylane_cirq/cirq_device.py
+++ b/pennylane_cirq/cirq_device.py
@@ -54,7 +54,7 @@ class CirqDevice(QubitDevice, abc.ABC):
     """
 
     name = "Cirq Abstract PennyLane plugin baseclass"
-    pennylane_requires = ">=0.8.0"
+    pennylane_requires = ">=0.9.0"
     version = __version__
     author = "Johannes Jakob Meyer"
     _capabilities = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pennylane>=0.8
+pennylane>=0.9
 cirq>=0.7
 numpy~=1.16

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,6 @@ classifiers = [
     "Programming Language :: Python",
     # Make sure to specify here the versions of Python supported
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3 :: Only",


### PR DESCRIPTION
* Python 3.5 support is removed (since Cirq doesn't officially support it).
* PennyLane requirements are bumped up to 0.9.
* Cirq requirements are bumped to 0.7 in `README.rst` (was already the case in `requirements.txt`).
* Minor changes are made in `README.rst` to work properly on PyPI (similiar to what was done [here](https://github.com/XanaduAI/pennylane-sf/pull/35)).


**Note**: Travis will fail because of using `networkx==2.3` instead of `networkx==2.4`, as written in `requirements.txt`. This is fixed in #27, and should thus work as soon as that PR is merged.