### PR TITLE
[WIP] Add pasqal device

### DIFF
--- a/pennylane_cirq/__init__.py
+++ b/pennylane_cirq/__init__.py
@@ -16,6 +16,7 @@ Plugin overview
 ===============
 """
 from .simulator_device import SimulatorDevice, MixedStateSimulatorDevice
+from .pasqal_device import PasqalDevice
 
 from .ops import BitFlip, PhaseFlip, PhaseDamp, AmplitudeDamp, Depolarize
 from ._version import __version__

--- a/pennylane_cirq/cirq_device.py
+++ b/pennylane_cirq/cirq_device.py
@@ -72,14 +72,12 @@ class CirqDevice(QubitDevice, abc.ABC):
         self.circuit = None
 
         if qubits:
-            if isinstance(qubits, cirq.LineQubit) and wires != len(qubits):
+            if wires != len(qubits):
                 raise qml.DeviceError(
                     "The number of given qubits and the specified number of wires have to match. Got {} wires and {} qubits.".format(
                         wires, len(qubits)
                     )
                 )
-            # flying blind; number of wires in PL may not match wires
-            # in ``qubits``
             self.qubits = qubits
         else:
             self.qubits = [cirq.LineQubit(wire) for wire in range(wires)]

--- a/pennylane_cirq/cirq_device.py
+++ b/pennylane_cirq/cirq_device.py
@@ -72,13 +72,14 @@ class CirqDevice(QubitDevice, abc.ABC):
         self.circuit = None
 
         if qubits:
-            if wires != len(qubits):
+            if isinstance(qubits, cirq.LineQubit) and wires != len(qubits):
                 raise qml.DeviceError(
                     "The number of given qubits and the specified number of wires have to match. Got {} wires and {} qubits.".format(
                         wires, len(qubits)
                     )
                 )
-
+            # flying blind; number of wires in PL may not match wires
+            # in ``qubits``
             self.qubits = qubits
         else:
             self.qubits = [cirq.LineQubit(wire) for wire in range(wires)]

--- a/pennylane_cirq/cirq_device.py
+++ b/pennylane_cirq/cirq_device.py
@@ -46,7 +46,7 @@ class CirqDevice(QubitDevice, abc.ABC):
     """Abstract base device for PennyLane-Cirq.
 
     Args:
-        wires (int): the number of modes to initialize the device in
+        wires (int): the number of wires to initialize the device with
         shots (int): Number of circuit evaluations/random samples used
             to estimate expectation values of observables. Shots need to be >= 1.
         qubits (List[cirq.Qubit]): a list of Cirq qubits that are used
@@ -78,6 +78,7 @@ class CirqDevice(QubitDevice, abc.ABC):
                         wires, len(qubits)
                     )
                 )
+
             self.qubits = qubits
         else:
             self.qubits = [cirq.LineQubit(wire) for wire in range(wires)]

--- a/pennylane_cirq/pasqal_device.py
+++ b/pennylane_cirq/pasqal_device.py
@@ -36,8 +36,7 @@ class PasqalDevice(SimulatorDevice):
             arrangement along the first coordinate axis,
             i.e., ``(0,0,0), (1,0,0), (2,0,0)``, etc.
         control_radius (float): The maximum distance between qubits for a controlled
-                gate. Distance is measured in units of the indices passed into
-                the qubits keyword argument.
+                gate. Distance is measured in units of the ``ThreeDGridQubit`` indices.
     """
     name = "Cirq Pasqal device for PennyLane"
     short_name = "cirq.pasqal"

--- a/pennylane_cirq/pasqal_device.py
+++ b/pennylane_cirq/pasqal_device.py
@@ -1,0 +1,68 @@
+# Copyright 2018 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Cirq Pasqal Devices
+======================
+
+**Module name:** :mod:`pennylane_cirq.pasqal_device`
+
+.. currentmodule:: pennylane_cirq.pasqal_device
+
+This Device implements exposes the ``PasqalDevice`` from Cirq.
+
+Classes
+-------
+
+.. autosummary::
+   PasqalDevice
+
+----
+"""
+from cirq import pasqal
+
+from .simulator_device import SimulatorDevice
+
+
+class PasqalDevice(SimulatorDevice):
+    r"""Cirq Pasqal device for PennyLane.
+
+    Args:
+        wires (int): the number of wires to initialize the device with
+        shots (int): Number of circuit evaluations/random samples used
+            to estimate expectation values of observables. Shots need
+            to >= 1. In analytic mode, shots indicates the number of entries
+            that are returned by ``device.sample``.
+        analytic (bool): Indicates that expectation values and variances should
+            be calculated analytically. Defaults to ``True``.
+        qubits (List[cirq.Qubit]): a list of Cirq qubits that are used
+            as wires. The wire number corresponds to the index in the list.
+            By default, an array of ``cirq.LineQubit`` instances is created.
+    """
+    name = "Cirq Pasqal device for PennyLane"
+    short_name = "cirq.pasqal"
+
+    def __init__(self, wires, shots=1000, analytic=True, qubits=None, control_radius=None):
+
+        if not qubits:
+            qubits = [pasqal.ThreeDGridQubit(wire) for wire in range(wires)]
+
+        self.control_radius = control_radius or 1.0
+
+        super().__init__(wires, shots, analytic, qubits)
+
+        self._simulator = pasqal.PasqalDevice(self.control_radius, self.qubits)
+
+        self._initial_state = None
+        self._result = None
+        self._state = None

--- a/pennylane_cirq/pasqal_device.py
+++ b/pennylane_cirq/pasqal_device.py
@@ -34,7 +34,7 @@ class PasqalDevice(SimulatorDevice):
         qubits (List[cirq.ThreeDGridQubit]): A list of Cirq ThreeDGridQubits that are used
             as wires. If not specified, the ThreeDGridQubits are put in a linear
             arrangement along the first coordinate axis,
-            i.e., (0,0,0), (1,0,0), (2,0,0), etc.
+            i.e., ``(0,0,0), (1,0,0), (2,0,0)``, etc.
         control_radius (float): The maximum distance between qubits for a controlled
                 gate. Distance is measured in units of the indices passed into
                 the qubits keyword argument.

--- a/pennylane_cirq/pasqal_device.py
+++ b/pennylane_cirq/pasqal_device.py
@@ -29,8 +29,8 @@ class PasqalDevice(SimulatorDevice):
             to estimate expectation values of observables. Shots need
             to be >= 1. In analytic mode, shots indicates the number of entries
             that are returned by ``device.sample``.
-        analytic (bool): Indicates whether expectation values and variances should
-            be calculated analytically. Defaults to ``True``.
+        analytic (bool): indicates whether expectation values and variances should
+            be calculated analytically
         qubits (List[cirq.ThreeDGridQubit]): A list of Cirq ThreeDGridQubits that are used
             as wires. If not specified, the ThreeDGridQubits are put in a linear
             arrangement along the first coordinate axis,

--- a/pennylane_cirq/pasqal_device.py
+++ b/pennylane_cirq/pasqal_device.py
@@ -12,22 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Cirq Pasqal Devices
-======================
-
-**Module name:** :mod:`pennylane_cirq.pasqal_device`
-
-.. currentmodule:: pennylane_cirq.pasqal_device
-
-This Device implements exposes the ``PasqalDevice`` from Cirq.
-
-Classes
--------
-
-.. autosummary::
-   PasqalDevice
-
-----
+This module provides the ``PasqalDevice`` from Cirq.
 """
 from cirq import pasqal
 

--- a/pennylane_cirq/pasqal_device.py
+++ b/pennylane_cirq/pasqal_device.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# pylint: disable=too-many-arguments
 """
 This module provides the ``PasqalDevice`` from Cirq.
 """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pennylane>=0.9
-cirq>=0.7
+git+https://github.com/lhenriet/Cirq.git
 numpy~=1.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pennylane>=0.9
+protobuf==3.8.0
 git+https://github.com/lhenriet/Cirq.git
 numpy~=1.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pennylane>=0.9
-protobuf==3.8.0
+google-api-core[grpc]<=1.14.0
 git+https://github.com/lhenriet/Cirq.git
 numpy~=1.16

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,8 @@ info = {
     "license": "Apache License 2.0",
     "packages": ["pennylane_cirq"],
     "entry_points": {"pennylane.plugins": ["cirq.simulator = pennylane_cirq:SimulatorDevice",
-                                           "cirq.mixedsimulator = pennylane_cirq:MixedStateSimulatorDevice"],},
+                                           "cirq.mixedsimulator = pennylane_cirq:MixedStateSimulatorDevice",
+                                           "cirq.pasqal = pennylane_cirq:PasqalDevice"],},
     # Place a one line description here. This will be shown by pip
     "description": "PennyLane plugin for Cirq",
     "long_description": open("README.rst").read(),


### PR DESCRIPTION
Adds a new device "cirq.pasqal", which uses the `cirq.pasqal.PasqalDevice` simulator as the execution backend. Cirq should be installed from the following fork: https://github.com/lhenriet/Cirq

Notes
-----

- Pasqal devices require `ThreeDGridQubit`s, which are qubits which have positions in three dimensions.
- Based on reading the plugin code, there are a number of places where an implicit assumption is made that the qubits are `LineQubit`:
    - in initialization of cirq_device.py
    - in _apply_basis_state in simulator_device.py
    - in _apply_qubit_state_vector in simulator_device.py
    - in apply in simulator_device.py
- It should be relatively straightforward to allow other qubit types (e.g., `GridQubit` or the `ThreeDGridQubit`s needed for the `PasqalDevice`, but it would require some small updates to the plugin to support more general cases than `LineQubit`. In particular, I identified that wherever `len` is called on the qubits, it will fail unless the qubits are `LineQubit`s.
- Fortunately, Cirq provides total ordering methods, so we can unambiguously assign every qubit in a grid a reproducible integer number, which allows us to map from PL's linear wire naming to the other schemes
- `PasqalDevice` also requires an initialization argument `control_radius`. Two qubits in the grid can undergo two-qubit gates iff they are within `control_radius` of one another

With the addition of better handling for different qubit arrangements, I think we can relatively easily add the `PasqalDevice`.

One option for the future is to perhaps expose the positions of the qubits in 3D space as a variable that Pennylane can tune and optimize, but I think it might be tricky at the moment, since it would require updating the qubits after the device is initialized (and I'm not exactly sure whether Cirq/Pasqal supports non-static arrangements yet)
